### PR TITLE
feat: Redesign website with neobrutalism style

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/default.min.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown-light.min.css" rel="stylesheet">
     <title>Dimas Maulana Dwi Saputra</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -1233,6 +1234,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -1276,6 +1287,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1588,6 +1600,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001580",
         "electron-to-chromium": "^1.4.648",
@@ -1785,6 +1798,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2088,6 +2107,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2229,6 +2249,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -2281,6 +2302,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
       "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "aria-query": "^5.3.0",
@@ -2311,6 +2333,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
       "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flatmap": "^1.3.1",
@@ -2341,6 +2364,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6434,6 +6458,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7421,6 +7446,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
       "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -8084,7 +8110,8 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -8094,7 +8121,8 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8103,7 +8131,9 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -8115,7 +8145,8 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -8165,13 +8196,15 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "extraneous": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
       "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -8186,13 +8219,15 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "extraneous": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/netlify-cli/node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "extraneous": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
@@ -8204,7 +8239,8 @@
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -8637,6 +8673,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8706,7 +8743,8 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "extraneous": true,
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12069,7 +12107,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "extraneous": true
+      "dev": true
     },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
@@ -13641,6 +13679,7 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -14517,7 +14556,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "extraneous": true
+      "dev": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -16973,6 +17012,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -19413,6 +19453,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20749,6 +20790,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -20760,6 +20802,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -21050,6 +21093,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
       "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -21656,6 +21700,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
       "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.32",
@@ -21904,6 +21949,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -22639,6 +22685,15 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
+    "@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "peer": true,
+      "requires": {
+        "csstype": "^3.2.2"
+      }
+    },
     "@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -22674,13 +22729,15 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -22899,6 +22956,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
       "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001580",
         "electron-to-chromium": "^1.4.648",
@@ -23034,6 +23092,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -23272,6 +23335,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -23449,6 +23513,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -23494,6 +23559,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
       "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.2",
         "aria-query": "^5.3.0",
@@ -23518,6 +23584,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
       "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.6",
         "array.prototype.flatmap": "^1.3.1",
@@ -23563,7 +23630,9 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -26249,6 +26318,7 @@
               "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
               "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
               "dev": true,
+              "peer": true,
               "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -26260,7 +26330,8 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
               "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-              "dev": true
+              "dev": true,
+              "requires": {}
             },
             "execa": {
               "version": "6.1.0",
@@ -26893,6 +26964,7 @@
           "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
           "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@octokit/auth-token": "^3.0.0",
             "@octokit/graphql": "^5.0.0",
@@ -26979,7 +27051,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
           "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "7.1.2",
@@ -27312,7 +27385,8 @@
           "version": "1.19.2",
           "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
           "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/connect": "*",
             "@types/node": "*"
@@ -27322,15 +27396,19 @@
           "version": "3.4.35",
           "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
           "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "*"
           }
         },
         "@types/express": {
-          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "version": "4.17.13",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
           "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "^4.17.18",
@@ -27342,7 +27420,8 @@
           "version": "4.17.28",
           "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
           "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "*",
             "@types/qs": "*",
@@ -27392,13 +27471,15 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
           "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "@types/node": {
           "version": "20.9.0",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
           "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -27413,13 +27494,15 @@
           "version": "6.9.7",
           "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
           "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "@types/range-parser": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
           "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "@types/retry": {
           "version": "0.12.1",
@@ -27431,7 +27514,8 @@
           "version": "1.13.10",
           "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
           "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/mime": "^1",
             "@types/node": "*"
@@ -27750,13 +27834,15 @@
           "version": "8.10.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
           "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "acorn-import-attributes": {
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.2.tgz",
           "integrity": "sha512-O+nfJwNolEA771IYJaiLWK1UAwjNsQmZbTRqqwBYxCgVQTmpFEMvBw6LOIQV0Me339L5UMVYFyRohGnGlQDdIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "acorn-walk": {
           "version": "8.3.2",
@@ -27792,9 +27878,11 @@
           }
         },
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -30344,7 +30432,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
           "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-          "extraneous": true
+          "dev": true
         },
         "fast-json-stringify": {
           "version": "5.7.0",
@@ -30567,7 +30655,8 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.1.tgz",
           "integrity": "sha512-bdrUUb0eYQrPRlaAtlSRoLs7sp6yKEwbMQuUgwvi/14TnaqhM/deSZUrC5ic+yjm5nEPPWE61oWpTTxQFQMmLA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "fecha": {
           "version": "4.2.1",
@@ -31524,6 +31613,7 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
           "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "ansi-escapes": "^3.2.0",
             "chalk": "^2.4.2",
@@ -32158,7 +32248,7 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "extraneous": true
+          "dev": true
         },
         "jsonc-parser": {
           "version": "3.2.0",
@@ -33961,6 +34051,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
           "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "nanoid": "^3.3.7",
             "picocolors": "^1.0.0",
@@ -35853,7 +35944,8 @@
           "version": "5.1.6",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
           "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "ufo": {
           "version": "1.3.1",
@@ -36426,7 +36518,8 @@
           "version": "8.14.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
           "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "xdg-basedir": {
           "version": "5.1.0",
@@ -36814,6 +36907,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -36822,6 +36916,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -36830,7 +36925,8 @@
     "react-icons": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw=="
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",
@@ -37013,6 +37109,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
       "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -37443,6 +37540,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
       "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.19.3",
         "fsevents": "~2.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,18 +916,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -1244,40 +1232,6 @@
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
-    },
-    "node_modules/@types/node": {
-      "version": "20.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.13.tgz",
-      "integrity": "sha512-5G4zQwdiQBSWYTDAH1ctw2eidqdhMJaNsiIDKHFr55ihz5Trl2qqR8fdrT732yPBho5gkNxXm67OxWFBqX9aPg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "peer": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.2.48",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
-      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -1647,14 +1601,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/call-bind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -1839,12 +1785,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8144,9 +8084,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -8156,9 +8094,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8167,9 +8103,7 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -8181,9 +8115,7 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -8233,9 +8165,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
@@ -8256,17 +8186,13 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
@@ -8278,9 +8204,7 @@
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -8782,8 +8706,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12146,8 +12069,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
@@ -14595,8 +14517,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -21232,29 +21153,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -21406,34 +21304,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
-      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -21607,14 +21477,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/unified": {
       "version": "11.0.4",
@@ -22550,18 +22412,6 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
-    "@jridgewell/source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -22789,40 +22639,6 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
-    "@types/node": {
-      "version": "20.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.13.tgz",
-      "integrity": "sha512-5G4zQwdiQBSWYTDAH1ctw2eidqdhMJaNsiIDKHFr55ihz5Trl2qqR8fdrT732yPBho5gkNxXm67OxWFBqX9aPg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "@types/prop-types": {
-      "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "peer": true
-    },
-    "@types/react": {
-      "version": "18.2.48",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
-      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "peer": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "peer": true
-    },
     "@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -22864,8 +22680,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -23091,14 +22906,6 @@
         "update-browserslist-db": "^1.0.13"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "call-bind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -23227,12 +23034,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "peer": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -23762,8 +23563,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -26460,8 +26260,7 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
               "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-              "dev": true,
-              "requires": {}
+              "dev": true
             },
             "execa": {
               "version": "6.1.0",
@@ -27180,8 +26979,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
           "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "7.1.2",
@@ -27514,9 +27312,7 @@
           "version": "1.19.2",
           "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
           "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "@types/connect": "*",
             "@types/node": "*"
@@ -27526,20 +27322,15 @@
           "version": "3.4.35",
           "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
           "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "@types/node": "*"
           }
         },
         "@types/express": {
-          "version": "4.17.13",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
           "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "^4.17.18",
@@ -27551,9 +27342,7 @@
           "version": "4.17.28",
           "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
           "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "@types/node": "*",
             "@types/qs": "*",
@@ -27603,9 +27392,7 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
           "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "extraneous": true
         },
         "@types/node": {
           "version": "20.9.0",
@@ -27626,17 +27413,13 @@
           "version": "6.9.7",
           "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
           "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "extraneous": true
         },
         "@types/range-parser": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
           "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "extraneous": true
         },
         "@types/retry": {
           "version": "0.12.1",
@@ -27648,9 +27431,7 @@
           "version": "1.13.10",
           "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
           "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "@types/mime": "^1",
             "@types/node": "*"
@@ -27975,8 +27756,7 @@
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.2.tgz",
           "integrity": "sha512-O+nfJwNolEA771IYJaiLWK1UAwjNsQmZbTRqqwBYxCgVQTmpFEMvBw6LOIQV0Me339L5UMVYFyRohGnGlQDdIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "acorn-walk": {
           "version": "8.3.2",
@@ -28012,11 +27792,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -30566,8 +30344,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
           "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "fast-json-stringify": {
           "version": "5.7.0",
@@ -30790,8 +30567,7 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.1.tgz",
           "integrity": "sha512-bdrUUb0eYQrPRlaAtlSRoLs7sp6yKEwbMQuUgwvi/14TnaqhM/deSZUrC5ic+yjm5nEPPWE61oWpTTxQFQMmLA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "fecha": {
           "version": "4.2.1",
@@ -32382,8 +32158,7 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "jsonc-parser": {
           "version": "3.2.0",
@@ -36651,8 +36426,7 @@
           "version": "8.14.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
           "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "xdg-basedir": {
           "version": "5.1.0",
@@ -37056,8 +36830,7 @@
     "react-icons": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
-      "requires": {}
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -37316,28 +37089,6 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -37445,30 +37196,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "terser": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
-      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -37597,14 +37324,6 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "unified": {
       "version": "11.0.4",

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -6,7 +6,7 @@ import NotebooksPage from '../Pages/NotebooksPage';
 import Navigation from '../Pures/Navigation';
 import { navigation } from '../../content';
 import NotebookPage from '../Pages/NotebookPage';
-import Footer from '../Pures/Footer';
+
 import './style.scss';
 import ThemeContext from '../../contexts/ThemeContext';
 
@@ -40,7 +40,7 @@ function App() {
               <Route path="/notebooks" element={<NotebooksPage />} />
               <Route path="/notebooks/:slug" element={<NotebookPage />} />
             </Routes>
-            <Footer />
+
           </div>
         </BrowserRouter>
       </div>

--- a/src/components/App/style.scss
+++ b/src/components/App/style.scss
@@ -1,18 +1,20 @@
 .page-container {
-  max-width: 1400px;
+  max-width: 1300px;
   margin: 0 auto;
-  padding: 48px 24px;
+  padding: 60px 32px;
   background-color: var(--surface);
-  border: 3px solid var(--on-background-border);
+  border: 2px solid var(--on-background-border);
   border-top: none;
   min-height: calc(100vh - 70px);
-  box-shadow: 0 4px 0 var(--shadow-color);
-  overflow-x: hidden;
+  box-shadow: 4px 4px 0 var(--shadow-color);
 }
 
 @media screen and (max-width: 767px) {
   .page-container {
-    padding: 24px 16px;
+    padding: 32px 16px;
     min-height: calc(100vh - 80px);
+    border-left: none;
+    border-right: none;
+    box-shadow: none;
   }
 }

--- a/src/components/App/style.scss
+++ b/src/components/App/style.scss
@@ -1,5 +1,10 @@
 .page-container {
-  max-width: 1000px;
+  max-width: 1400px;
   margin: 0 auto;
-  padding: 36px 0;
+  padding: 48px 24px;
+  background-color: var(--surface);
+  border: 3px solid var(--on-background-border);
+  border-top: none;
+  min-height: calc(100vh - 70px);
+  box-shadow: 0 4px 0 var(--shadow-color);
 }

--- a/src/components/App/style.scss
+++ b/src/components/App/style.scss
@@ -7,4 +7,12 @@
   border-top: none;
   min-height: calc(100vh - 70px);
   box-shadow: 0 4px 0 var(--shadow-color);
+  overflow-x: hidden;
+}
+
+@media screen and (max-width: 767px) {
+  .page-container {
+    padding: 24px 16px;
+    min-height: calc(100vh - 80px);
+  }
 }

--- a/src/components/Pages/AboutPage/style.scss
+++ b/src/components/Pages/AboutPage/style.scss
@@ -2,18 +2,29 @@
   min-height: 75vh;
 
   .about__title {
+    display: inline-block;
+    font-size: 1.75rem;
+    font-weight: 800;
     margin-bottom: 32px;
-    font-size: 18px;
+    padding: 10px 20px;
+    background-color: var(--primary);
+    color: white;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .markdown-body {
-    font-family: 'Inter', sans-serif;
-    line-height: 1.75;
-    background-color: var(--background);
+    font-family: 'DM Sans', sans-serif;
+    line-height: 1.8;
+    background-color: transparent;
     color: var(--on-background);
+    font-weight: 500;
   }
 
   .markdown-body blockquote {
     color: var(--on-background-grey);
+    border-left: 4px solid var(--primary);
+    padding-left: 16px;
   }
 }

--- a/src/components/Pages/HomePage/index.jsx
+++ b/src/components/Pages/HomePage/index.jsx
@@ -13,7 +13,7 @@ function HomePage() {
       <PersonalInformation />
 
       <div className="home-page__marquee-strip">
-        <Marquee speed={25}>
+        <Marquee speed={50}>
           {tags.map(({ name, icon: Icon }) => (
             <span key={name} className="home-page__marquee-item">
               <Icon />
@@ -24,7 +24,7 @@ function HomePage() {
       </div>
 
       <div className="home-page__marquee-strip home-page__marquee-strip--reverse">
-        <Marquee speed={20} reverse>
+        <Marquee speed={45} reverse>
           {tags.map(({ name, icon: Icon }) => (
             <span key={name} className="home-page__marquee-item home-page__marquee-item--alt">
               <Icon />

--- a/src/components/Pages/HomePage/index.jsx
+++ b/src/components/Pages/HomePage/index.jsx
@@ -4,11 +4,36 @@ import './style.scss';
 import TechStack from '../../Pures/TechStack';
 import WorkHistories from '../../Pures/WorkHistories';
 import Badges from '../../Pures/Badges';
+import Marquee from '../../Pures/Marquee';
+import { tags } from '../../../content';
 
 function HomePage() {
   return (
-    <main>
+    <main className="home-page">
       <PersonalInformation />
+
+      <div className="home-page__marquee-strip">
+        <Marquee speed={25}>
+          {tags.map(({ name, icon: Icon }) => (
+            <span key={name} className="home-page__marquee-item">
+              <Icon />
+              {name}
+            </span>
+          ))}
+        </Marquee>
+      </div>
+
+      <div className="home-page__marquee-strip home-page__marquee-strip--reverse">
+        <Marquee speed={20} reverse>
+          {tags.map(({ name, icon: Icon }) => (
+            <span key={name} className="home-page__marquee-item home-page__marquee-item--alt">
+              <Icon />
+              {name}
+            </span>
+          ))}
+        </Marquee>
+      </div>
+
       <TechStack />
       <WorkHistories />
       <Badges />

--- a/src/components/Pages/HomePage/style.scss
+++ b/src/components/Pages/HomePage/style.scss
@@ -1,22 +1,64 @@
-.home-brutal {
-  /* Hapus background container dan border nesting */
-  padding: 24px;
-  overflow-x: hidden;
+.home-page {
+  overflow: visible;
   position: relative;
-
-  /* Jangan ada border di outer container */
 }
 
-@media screen and (min-width: 1024px) {
-  .home-brutal {
-    padding: 48px 32px;
-    max-width: 1200px;
-    margin: 0 auto;
+.home-page__marquee-strip {
+  /* Full bleed: escape container completely */
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%) rotate(-1deg);
+  margin: 48px 0;
+  padding: 16px 0;
+  background-color: var(--primary);
+  border-top: 2px solid var(--on-background-border);
+  border-bottom: 2px solid var(--on-background-border);
+  overflow: hidden;
+
+  &--reverse {
+    background-color: var(--secondary);
+    transform: translateX(-50%) rotate(1deg);
+    margin-top: -8px;
+  }
+
+  .home-page__marquee-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 24px;
+    font-size: 1.125rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: white;
+    white-space: nowrap;
+
+    svg {
+      width: 22px;
+      height: 22px;
+    }
+
+    &--alt {
+      color: #000000;
+    }
   }
 }
 
 @media screen and (max-width: 767px) {
-  .home-brutal {
-    padding: 24px 16px;
+  .home-page__marquee-strip {
+    margin: 32px 0;
+    padding: 12px 0;
+
+    .home-page__marquee-item {
+      font-size: 0.875rem;
+      padding: 6px 16px;
+      gap: 8px;
+
+      svg {
+        width: 18px;
+        height: 18px;
+      }
+    }
   }
 }

--- a/src/components/Pages/HomePage/style.scss
+++ b/src/components/Pages/HomePage/style.scss
@@ -1,32 +1,22 @@
-main {
+.home-brutal {
+  /* Hapus background container dan border nesting */
   padding: 24px;
-  background-color: var(--background);
-  border: 3px solid var(--on-background-border);
-  border-radius: 0;
-  box-shadow: 6px 6px 0 var(--shadow-color);
   overflow-x: hidden;
+  position: relative;
 
-  .main__container {
+  /* Jangan ada border di outer container */
+}
+
+@media screen and (min-width: 1024px) {
+  .home-brutal {
+    padding: 48px 32px;
     max-width: 1200px;
     margin: 0 auto;
-    padding: 36px 0;
-
-    > * {
-      margin-bottom: 32px;
-    }
   }
 }
 
 @media screen and (max-width: 767px) {
-  main {
-    padding: 16px 12px;
-
-    .main__container {
-      padding: 24px 0;
-
-      > * {
-        margin-bottom: 24px;
-      }
-    }
+  .home-brutal {
+    padding: 24px 16px;
   }
 }

--- a/src/components/Pages/HomePage/style.scss
+++ b/src/components/Pages/HomePage/style.scss
@@ -4,6 +4,7 @@ main {
   border: 3px solid var(--on-background-border);
   border-radius: 0;
   box-shadow: 6px 6px 0 var(--shadow-color);
+  overflow-x: hidden;
 
   .main__container {
     max-width: 1200px;
@@ -12,6 +13,20 @@ main {
 
     > * {
       margin-bottom: 32px;
+    }
+  }
+}
+
+@media screen and (max-width: 767px) {
+  main {
+    padding: 16px 12px;
+
+    .main__container {
+      padding: 24px 0;
+
+      > * {
+        margin-bottom: 24px;
+      }
     }
   }
 }

--- a/src/components/Pages/HomePage/style.scss
+++ b/src/components/Pages/HomePage/style.scss
@@ -1,9 +1,17 @@
 main {
-  padding: 12px;
+  padding: 24px;
+  background-color: var(--background);
+  border: 3px solid var(--on-background-border);
+  border-radius: 0;
+  box-shadow: 6px 6px 0 var(--shadow-color);
 
   .main__container {
-    max-width: 750px;
+    max-width: 1200px;
     margin: 0 auto;
     padding: 36px 0;
+
+    > * {
+      margin-bottom: 32px;
+    }
   }
 }

--- a/src/components/Pages/NotebookPage/index.jsx
+++ b/src/components/Pages/NotebookPage/index.jsx
@@ -26,8 +26,32 @@ function NotebookPage() {
     })();
   }, []);
 
+  // Show skeleton while loading
   if (content === '') {
-    return <div />;
+    return (
+      <main className="notebook-detail skeleton-loading">
+        <header>
+          <div className="skeleton skeleton__title" />
+          <div className="notebook-detail__tags">
+            <div className="skeleton skeleton__tag" />
+            <div className="skeleton skeleton__tag" />
+            <div className="skeleton skeleton__tag" />
+          </div>
+        </header>
+        <div className="markdown-body skeleton-content">
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--long" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--long" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--medium" />
+          <div className="skeleton skeleton__block" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--long" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--medium" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--short" />
+          <div className="skeleton skeleton__block" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--long" />
+          <div className="skeleton skeleton__paragraph skeleton__paragraph--medium" />
+        </div>
+      </main>
+    );
   }
 
   const { title } = notebook;

--- a/src/components/Pages/NotebookPage/style.scss
+++ b/src/components/Pages/NotebookPage/style.scss
@@ -6,28 +6,37 @@
   }
 
   h3 {
-    font-size: 2rem;
+    font-size: 1.75rem;
   }
 
   p, li, pre, h4, h5, h6 {
-    font-size: 1.2rem;
+    font-size: 1.125rem;
   }
 
   header {
-    margin-bottom: 32px;
+    margin-bottom: 40px;
 
     .notebook-detail__title {
-      font-size: 2.7rem;
-      margin-bottom: 18px;
+      font-size: 2.5rem;
+      font-weight: 800;
+      margin-bottom: 20px;
+      line-height: 1.1;
     }
 
     .notebook-detail__tags {
 
       .notebook-detail__tag {
-        padding: 4px 12px;
-        border-radius: 4px;
-        border: 1px solid var(--on-background);
-        margin: 0 8px 0 0;
+        display: inline-block;
+        padding: 5px 14px;
+        border-radius: var(--border-radius);
+        border: 2px solid var(--on-background-border);
+        margin: 0 8px 8px 0;
+        font-weight: 700;
+        font-size: 0.8125rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        background-color: var(--surface);
+        box-shadow: 2px 2px 0 var(--shadow-color);
       }
 
       .notebook-detail__tag::before {
@@ -37,23 +46,30 @@
   }
 
   .markdown-body {
-    font-family: 'Inter', sans-serif;
-    line-height: 1.75;
-    background-color: var(--background);
+    font-family: 'DM Sans', sans-serif;
+    line-height: 1.8;
+    background-color: transparent;
     color: var(--on-background);
+    font-weight: 500;
 
     pre {
       color: #333333;
+      border: 2px solid var(--on-background-border);
+      border-radius: var(--border-radius);
     }
 
     img {
       width: 100%;
-      border-radius: 8px;
+      border-radius: var(--border-radius);
+      border: 2px solid var(--on-background-border);
+      box-shadow: 4px 4px 0 var(--shadow-color);
     }
-  }
 
-  .markdown-body blockquote {
-    color: var(--on-background-grey);
+    blockquote {
+      border-left: 4px solid var(--primary);
+      padding-left: 16px;
+      color: var(--on-background-grey);
+    }
   }
 }
 
@@ -72,7 +88,7 @@
   background: linear-gradient(90deg, var(--background) 25%, var(--on-background-border) 50%, var(--background) 75%);
   background-size: 1000px 100%;
   animation: shimmer 2s infinite linear;
-  border-radius: 0;
+  border-radius: var(--border-radius);
   border: 2px solid var(--on-background-border);
 }
 
@@ -80,7 +96,6 @@
   height: 2.7rem;
   width: 80%;
   margin-bottom: 18px;
-  border-width: 3px;
 }
 
 .skeleton__tag {
@@ -88,31 +103,11 @@
   width: 80px;
   display: inline-block;
   margin-right: 12px;
-  border-width: 2px;
-}
-
-.skeleton__line {
-  height: 24px;
-  margin-bottom: 16px;
-  border-width: 2px;
-
-  &--short {
-    width: 60%;
-  }
-
-  &--medium {
-    width: 80%;
-  }
-
-  &--long {
-    width: 100%;
-  }
 }
 
 .skeleton__paragraph {
   height: 16px;
   margin-bottom: 12px;
-  border-width: 2px;
 
   &--short {
     width: 90%;
@@ -130,30 +125,21 @@
 .skeleton__block {
   height: 150px;
   margin-bottom: 24px;
-  border-width: 3px;
   width: 100%;
 }
 
 @media screen and (max-width: 767px) {
+  .notebook-detail {
+    header {
+      .notebook-detail__title {
+        font-size: 1.75rem;
+      }
+    }
+  }
+
   .skeleton__title {
     height: 2rem;
     width: 100%;
-  }
-
-  .skeleton__line {
-    height: 20px;
-
-    &--short {
-      width: 80%;
-    }
-
-    &--medium {
-      width: 90%;
-    }
-
-    &--long {
-      width: 100%;
-    }
   }
 
   .skeleton__paragraph {
@@ -163,10 +149,7 @@
       width: 95%;
     }
 
-    &--medium {
-      width: 100%;
-    }
-
+    &--medium,
     &--long {
       width: 100%;
     }

--- a/src/components/Pages/NotebookPage/style.scss
+++ b/src/components/Pages/NotebookPage/style.scss
@@ -56,3 +56,123 @@
     color: var(--on-background-grey);
   }
 }
+
+/* Skeleton Loading Styles */
+@keyframes shimmer {
+  0% {
+    background-position: -1000px 0;
+  }
+
+  100% {
+    background-position: 1000px 0;
+  }
+}
+
+.skeleton {
+  background: linear-gradient(90deg, var(--background) 25%, var(--on-background-border) 50%, var(--background) 75%);
+  background-size: 1000px 100%;
+  animation: shimmer 2s infinite linear;
+  border-radius: 0;
+  border: 2px solid var(--on-background-border);
+}
+
+.skeleton__title {
+  height: 2.7rem;
+  width: 80%;
+  margin-bottom: 18px;
+  border-width: 3px;
+}
+
+.skeleton__tag {
+  height: 32px;
+  width: 80px;
+  display: inline-block;
+  margin-right: 12px;
+  border-width: 2px;
+}
+
+.skeleton__line {
+  height: 24px;
+  margin-bottom: 16px;
+  border-width: 2px;
+
+  &--short {
+    width: 60%;
+  }
+
+  &--medium {
+    width: 80%;
+  }
+
+  &--long {
+    width: 100%;
+  }
+}
+
+.skeleton__paragraph {
+  height: 16px;
+  margin-bottom: 12px;
+  border-width: 2px;
+
+  &--short {
+    width: 90%;
+  }
+
+  &--medium {
+    width: 95%;
+  }
+
+  &--long {
+    width: 100%;
+  }
+}
+
+.skeleton__block {
+  height: 150px;
+  margin-bottom: 24px;
+  border-width: 3px;
+  width: 100%;
+}
+
+@media screen and (max-width: 767px) {
+  .skeleton__title {
+    height: 2rem;
+    width: 100%;
+  }
+
+  .skeleton__line {
+    height: 20px;
+
+    &--short {
+      width: 80%;
+    }
+
+    &--medium {
+      width: 90%;
+    }
+
+    &--long {
+      width: 100%;
+    }
+  }
+
+  .skeleton__paragraph {
+    height: 14px;
+
+    &--short {
+      width: 95%;
+    }
+
+    &--medium {
+      width: 100%;
+    }
+
+    &--long {
+      width: 100%;
+    }
+  }
+
+  .skeleton__block {
+    height: 100px;
+  }
+}

--- a/src/components/Pages/NotebooksPage/style.scss
+++ b/src/components/Pages/NotebooksPage/style.scss
@@ -2,11 +2,22 @@
   min-height: 75vh;
 
   .notebook-page__title {
-    font-size: 24px;
-    margin-bottom: 8px;
+    display: inline-block;
+    font-size: 1.75rem;
+    font-weight: 800;
+    margin-bottom: 12px;
+    padding: 10px 20px;
+    background-color: var(--primary);
+    color: white;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .notebook-page__subtitle {
-    font-weight: lighter;
+    font-weight: 500;
+    font-size: 1.0625rem;
+    color: var(--on-background-grey);
+    margin-top: 8px;
   }
 }

--- a/src/components/Pures/AnnouncementBar/style.scss
+++ b/src/components/Pures/AnnouncementBar/style.scss
@@ -1,48 +1,73 @@
 .announcement-bar {
-  padding: 8px 16px;
-  background-color: #191414;
+  padding: 12px 24px;
+  background-color: #1DB954;
   color: white;
   display: flex;
   justify-content: center;
   align-items: center;
-
+  border-bottom: 3px solid var(--on-background-border);
+  box-shadow: 0 4px 0 var(--shadow-color);
 
   .announcement-bar__content {
     flex: 1;
     display: flex;
     justify-content: center;
     align-items: center;
-
+    gap: 12px;
 
     svg {
-      color: #1DB954;
-      width: 18px;
-      height: 18px;
-      margin-right: 8px;
+      color: white;
+      width: 24px;
+      height: 24px;
     }
 
     p {
-      font-size: 12px;
+      font-size: 0.875rem;
+      font-weight: 700;
       text-align: center;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin: 0;
 
       a {
         color: white;
-        font-weight: bold;
+        font-weight: 700;
         text-decoration: none;
-      }
+        text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.2);
+        transition: all 0.1s ease;
 
-      a:hover {
-        text-decoration: underline;
-        color: #1DB954;
+        &:hover {
+          text-decoration: underline;
+          transform: translate(1px, 1px);
+        }
       }
     }
   }
 
   button {
-    background-color: transparent;
-    border: 0;
-    color: white;
+    background-color: white;
+    color: #1DB954;
+    border: 3px solid var(--on-background-border);
     cursor: pointer;
+    font-size: 18px;
+    font-weight: 700;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 3px 3px 0 var(--shadow-color);
+    transition: all 0.1s ease;
+
+    &:hover {
+      transform: translate(2px, 2px);
+      box-shadow: 1px 1px 0 var(--shadow-color);
+    }
+
+    &:active {
+      transform: translate(3px, 3px);
+      box-shadow: none;
+    }
   }
 }
 
@@ -52,10 +77,18 @@
 
 @media screen and (min-width: 600px){
   .announcement-bar{
+    padding: 14px 32px;
+
     .announcement-bar__content {
       p {
-        font-size: 14px;
+        font-size: 1rem;
       };
+    }
+
+    button {
+      width: 48px;
+      height: 48px;
+      font-size: 20px;
     }
   }
 }

--- a/src/components/Pures/AnnouncementBar/style.scss
+++ b/src/components/Pures/AnnouncementBar/style.scss
@@ -14,11 +14,13 @@
     justify-content: center;
     align-items: center;
     gap: 12px;
+    min-width: 0;
 
     svg {
       color: white;
       width: 24px;
       height: 24px;
+      flex-shrink: 0;
     }
 
     p {
@@ -28,6 +30,8 @@
       text-transform: uppercase;
       letter-spacing: 0.05em;
       margin: 0;
+      word-break: break-word;
+      overflow-wrap: break-word;
 
       a {
         color: white;
@@ -58,6 +62,7 @@
     justify-content: center;
     box-shadow: 3px 3px 0 var(--shadow-color);
     transition: all 0.1s ease;
+    flex-shrink: 0;
 
     &:hover {
       transform: translate(2px, 2px);
@@ -89,6 +94,32 @@
       width: 48px;
       height: 48px;
       font-size: 20px;
+    }
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .announcement-bar {
+    padding: 10px 16px;
+
+    .announcement-bar__content {
+      gap: 8px;
+
+      svg {
+        width: 20px;
+        height: 20px;
+      }
+
+      p {
+        font-size: 0.75rem;
+        letter-spacing: 0.03em;
+      }
+    }
+
+    button {
+      width: 36px;
+      height: 36px;
+      font-size: 16px;
     }
   }
 }

--- a/src/components/Pures/AnnouncementBar/style.scss
+++ b/src/components/Pures/AnnouncementBar/style.scss
@@ -5,8 +5,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border-bottom: 3px solid var(--on-background-border);
-  box-shadow: 0 4px 0 var(--shadow-color);
+  /* Hapus border-bottom dan box-shadow */
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 
   .announcement-bar__content {
     flex: 1;
@@ -37,12 +39,12 @@
         color: white;
         font-weight: 700;
         text-decoration: none;
-        text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.2);
-        transition: all 0.1s ease;
+        border-bottom: 3px solid transparent;
+        transition: all 0.2s ease;
 
         &:hover {
-          text-decoration: underline;
-          transform: translate(1px, 1px);
+          border-bottom-color: white;
+          text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
         }
       }
     }
@@ -51,7 +53,7 @@
   button {
     background-color: white;
     color: #1DB954;
-    border: 3px solid var(--on-background-border);
+    border: 3px solid white;
     cursor: pointer;
     font-size: 18px;
     font-weight: 700;
@@ -60,13 +62,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 3px 3px 0 var(--shadow-color);
-    transition: all 0.1s ease;
+    box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.3);
+    transition: all 0.2s ease;
     flex-shrink: 0;
+    /* Hapus skew transformation */
 
     &:hover {
       transform: translate(2px, 2px);
-      box-shadow: 1px 1px 0 var(--shadow-color);
+      box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
     }
 
     &:active {

--- a/src/components/Pures/AnnouncementBar/style.scss
+++ b/src/components/Pures/AnnouncementBar/style.scss
@@ -1,14 +1,11 @@
 .announcement-bar {
-  padding: 12px 24px;
+  padding: 10px 24px;
   background-color: #1DB954;
   color: white;
   display: flex;
   justify-content: center;
   align-items: center;
-  /* Hapus border-bottom dan box-shadow */
-  position: sticky;
-  top: 0;
-  z-index: 1000;
+  border-bottom: 2px solid var(--on-background-border);
 
   .announcement-bar__content {
     flex: 1;
@@ -17,11 +14,12 @@
     align-items: center;
     gap: 12px;
     min-width: 0;
+    overflow: hidden;
 
     svg {
       color: white;
-      width: 24px;
-      height: 24px;
+      width: 22px;
+      height: 22px;
       flex-shrink: 0;
     }
 
@@ -32,19 +30,19 @@
       text-transform: uppercase;
       letter-spacing: 0.05em;
       margin: 0;
-      word-break: break-word;
-      overflow-wrap: break-word;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
       a {
         color: white;
         font-weight: 700;
         text-decoration: none;
-        border-bottom: 3px solid transparent;
-        transition: all 0.2s ease;
+        border-bottom: 2px solid transparent;
+        transition: border-color 0.2s ease;
 
         &:hover {
           border-bottom-color: white;
-          text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
         }
       }
     }
@@ -53,26 +51,21 @@
   button {
     background-color: white;
     color: #1DB954;
-    border: 3px solid white;
+    border: 2px solid white;
+    border-radius: var(--border-radius);
     cursor: pointer;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 700;
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
     display: flex;
     align-items: center;
     justify-content: center;
     box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.3);
-    transition: all 0.2s ease;
+    transition: all 0.1s ease;
     flex-shrink: 0;
-    /* Hapus skew transformation */
 
     &:hover {
-      transform: translate(2px, 2px);
-      box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
-    }
-
-    &:active {
       transform: translate(3px, 3px);
       box-shadow: none;
     }
@@ -83,34 +76,34 @@
   display: none;
 }
 
-@media screen and (min-width: 600px){
-  .announcement-bar{
-    padding: 14px 32px;
+@media screen and (min-width: 600px) {
+  .announcement-bar {
+    padding: 12px 32px;
 
     .announcement-bar__content {
       p {
-        font-size: 1rem;
-      };
+        font-size: 0.9375rem;
+      }
     }
 
     button {
-      width: 48px;
-      height: 48px;
-      font-size: 20px;
+      width: 40px;
+      height: 40px;
+      font-size: 18px;
     }
   }
 }
 
 @media screen and (max-width: 599px) {
   .announcement-bar {
-    padding: 10px 16px;
+    padding: 8px 12px;
 
     .announcement-bar__content {
       gap: 8px;
 
       svg {
-        width: 20px;
-        height: 20px;
+        width: 18px;
+        height: 18px;
       }
 
       p {
@@ -120,9 +113,9 @@
     }
 
     button {
-      width: 36px;
-      height: 36px;
-      font-size: 16px;
+      width: 32px;
+      height: 32px;
+      font-size: 14px;
     }
   }
 }

--- a/src/components/Pures/Badges/index.jsx
+++ b/src/components/Pures/Badges/index.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { badges } from '../../../content';
+import Marquee from '../Marquee';
 
 import './style.scss';
 
 function Badge({ name, image, link }) {
   return (
     <div className="badge">
-      <a href={link} target="_blank" rel="noreferrer" title={name}><img src={image} alt={name} /></a>
+      <a href={link} target="_blank" rel="noreferrer" title={name}>
+        <img src={image} alt={name} />
+        <span className="badge__name">{name}</span>
+      </a>
     </div>
   );
 }
@@ -18,14 +22,28 @@ Badge.propTypes = {
   link: PropTypes.string.isRequired,
 };
 
+const firstRow = badges.slice(0, 4);
+const secondRow = badges.slice(4);
+
 function Badges() {
   return (
     <div className="badges">
       <h3>Badges/Certificates</h3>
-      <div className="badges__list">
-        {badges.map(({ name, image, link }) => (
-          <Badge key={name} name={name} image={image} link={link} />
-        ))}
+      <div className="badges__showcase">
+        <div className="badges__row">
+          <Marquee speed={40}>
+            {firstRow.map(({ name, image, link }) => (
+              <Badge key={name} name={name} image={image} link={link} />
+            ))}
+          </Marquee>
+        </div>
+        <div className="badges__row">
+          <Marquee speed={35} reverse>
+            {secondRow.map(({ name, image, link }) => (
+              <Badge key={name} name={name} image={image} link={link} />
+            ))}
+          </Marquee>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Pures/Badges/style.scss
+++ b/src/components/Pures/Badges/style.scss
@@ -1,12 +1,7 @@
 .badges {
   margin-top: 48px;
-  padding-bottom: 32px;
-  border-bottom: 3px solid var(--on-background-border);
-  background-color: var(--surface);
-  border: 3px solid var(--on-background-border);
-  box-shadow: 6px 6px 0 var(--shadow-color);
-  padding: 32px;
-  overflow-x: hidden;
+  /* Hapus border-bottom dan container background */
+  margin-bottom: 32px;
 
   h3 {
     font-size: 1.5rem;
@@ -28,14 +23,15 @@
 
     .badge {
       padding: 16px;
-      background-color: var(--background);
+      background-color: var(--surface);
       border: 3px solid var(--on-background-border);
       box-shadow: 4px 4px 0 var(--shadow-color);
       transition: all 0.1s ease;
 
       &:hover {
         transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        box-shadow: 2px 2px 0 var(--shadow-color));
+        border-color: var(--primary);
       }
 
       img {
@@ -51,8 +47,8 @@
 @media screen and (max-width: 599px) {
   .badges {
     margin-top: 32px;
-    padding-bottom: 32px;
-    padding: 20px 16px;
+    margin-bottom: 32px;
+    /* Hapus padding di mobile untuk hemat space */
 
     h3 {
       font-size: 1.25rem;

--- a/src/components/Pures/Badges/style.scss
+++ b/src/components/Pures/Badges/style.scss
@@ -30,7 +30,7 @@
 
       &:hover {
         transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color));
+        box-shadow: 2px 2px 0 var(--shadow-color);
         border-color: var(--primary);
       }
 

--- a/src/components/Pures/Badges/style.scss
+++ b/src/components/Pures/Badges/style.scss
@@ -17,36 +17,66 @@
     box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
-  .badges__list {
-    margin-top: 0;
-    display: grid;
-    gap: 20px;
-    align-items: stretch;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  .badges__showcase {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    /* Full bleed */
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+  }
 
-    .badge {
-      padding: 16px;
+  .badges__row {
+    overflow: hidden;
+  }
+
+  .badge {
+    flex-shrink: 0;
+    width: 260px;
+
+    a {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px;
       background-color: var(--surface);
       border: 2px solid var(--on-background-border);
       border-radius: var(--border-radius);
       box-shadow: 4px 4px 0 var(--shadow-color);
-      transition: all 0.1s ease;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      transition: all 0.15s ease;
+      text-decoration: none;
+      height: 100%;
 
       &:hover {
         transform: translate(4px, 4px);
         box-shadow: none;
         border-color: var(--primary);
-      }
 
-      img {
-        width: 100%;
-        display: block;
-        max-width: 100%;
-        height: auto;
+        .badge__name {
+          color: var(--primary);
+        }
       }
+    }
+
+    img {
+      width: 100%;
+      max-height: 160px;
+      object-fit: contain;
+      display: block;
+      margin-bottom: 12px;
+    }
+
+    .badge__name {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--on-background-grey);
+      text-align: center;
+      line-height: 1.3;
+      transition: color 0.15s ease;
     }
   }
 }
@@ -55,6 +85,10 @@
   .badges {
     h3 {
       font-size: 1.75rem;
+    }
+
+    .badge {
+      width: 280px;
     }
   }
 }
@@ -69,12 +103,24 @@
       margin-bottom: 20px;
     }
 
-    .badges__list {
-      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    .badges__showcase {
       gap: 12px;
+    }
 
-      .badge {
-        padding: 12px;
+    .badge {
+      width: 200px;
+
+      a {
+        padding: 14px;
+      }
+
+      img {
+        max-height: 120px;
+        margin-bottom: 8px;
+      }
+
+      .badge__name {
+        font-size: 0.625rem;
       }
     }
   }

--- a/src/components/Pures/Badges/style.scss
+++ b/src/components/Pures/Badges/style.scss
@@ -6,6 +6,7 @@
   border: 3px solid var(--on-background-border);
   box-shadow: 6px 6px 0 var(--shadow-color);
   padding: 32px;
+  overflow-x: hidden;
 
   h3 {
     font-size: 1.5rem;
@@ -15,6 +16,7 @@
     color: var(--primary);
     margin-bottom: 24px;
     text-shadow: 2px 2px 0 var(--shadow-color);
+    word-break: break-word;
   }
 
   .badges__list {
@@ -39,6 +41,31 @@
       img {
         width: 100%;
         display: block;
+        max-width: 100%;
+        height: auto;
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .badges {
+    margin-top: 32px;
+    padding-bottom: 32px;
+    padding: 20px 16px;
+
+    h3 {
+      font-size: 1.25rem;
+      margin-bottom: 16px;
+    }
+
+    .badges__list {
+      margin-top: 16px;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      gap: 12px;
+
+      .badge {
+        padding: 12px;
       }
     }
   }

--- a/src/components/Pures/Badges/style.scss
+++ b/src/components/Pures/Badges/style.scss
@@ -1,36 +1,43 @@
 .badges {
-  margin-top: 48px;
-  /* Hapus border-bottom dan container background */
-  margin-bottom: 32px;
+  margin-top: 80px;
+  margin-bottom: 48px;
 
   h3 {
+    display: inline-block;
     font-size: 1.5rem;
-    font-weight: 700;
+    font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--primary);
-    margin-bottom: 24px;
-    text-shadow: 2px 2px 0 var(--shadow-color);
-    word-break: break-word;
+    letter-spacing: 0.08em;
+    color: #000000;
+    margin-bottom: 32px;
+    padding: 10px 20px;
+    background-color: var(--warning);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .badges__list {
-    margin-top: 32px;
+    margin-top: 0;
     display: grid;
     gap: 20px;
-    align-items: center;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    align-items: stretch;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 
     .badge {
       padding: 16px;
       background-color: var(--surface);
-      border: 3px solid var(--on-background-border);
+      border: 2px solid var(--on-background-border);
+      border-radius: var(--border-radius);
       box-shadow: 4px 4px 0 var(--shadow-color);
       transition: all 0.1s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       &:hover {
-        transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        transform: translate(4px, 4px);
+        box-shadow: none;
         border-color: var(--primary);
       }
 
@@ -44,20 +51,26 @@
   }
 }
 
+@media screen and (min-width: 600px) {
+  .badges {
+    h3 {
+      font-size: 1.75rem;
+    }
+  }
+}
+
 @media screen and (max-width: 599px) {
   .badges {
-    margin-top: 32px;
+    margin-top: 48px;
     margin-bottom: 32px;
-    /* Hapus padding di mobile untuk hemat space */
 
     h3 {
       font-size: 1.25rem;
-      margin-bottom: 16px;
+      margin-bottom: 20px;
     }
 
     .badges__list {
-      margin-top: 16px;
-      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
       gap: 12px;
 
       .badge {

--- a/src/components/Pures/Badges/style.scss
+++ b/src/components/Pures/Badges/style.scss
@@ -1,22 +1,44 @@
 .badges {
   margin-top: 48px;
   padding-bottom: 32px;
-  border-bottom: 1px solid var(--on-background-border);
+  border-bottom: 3px solid var(--on-background-border);
+  background-color: var(--surface);
+  border: 3px solid var(--on-background-border);
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  padding: 32px;
 
   h3 {
-    font-size: 16px;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--primary);
+    margin-bottom: 24px;
+    text-shadow: 2px 2px 0 var(--shadow-color);
   }
 
   .badges__list {
     margin-top: 32px;
     display: grid;
-    gap: 16px;
+    gap: 20px;
     align-items: center;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 
     .badge {
+      padding: 16px;
+      background-color: var(--background);
+      border: 3px solid var(--on-background-border);
+      box-shadow: 4px 4px 0 var(--shadow-color);
+      transition: all 0.1s ease;
+
+      &:hover {
+        transform: translate(2px, 2px);
+        box-shadow: 2px 2px 0 var(--shadow-color);
+      }
+
       img {
         width: 100%;
+        display: block;
       }
     }
   }

--- a/src/components/Pures/Footer/index.jsx
+++ b/src/components/Pures/Footer/index.jsx
@@ -4,20 +4,27 @@ import './style.scss';
 function Footer() {
   return (
     <footer className="footer">
-      <div className="footer__copyright">
-        <p>
-          Copyright ©
-          { new Date().getFullYear() }
-          {' '}
-          Dimas Maulana Dwi Saputra
-        </p>
-      </div>
-      <div className="footer__design-inspired">
-        <p>
-          Design inspired by
-          {' '}
-          <a href="https://showwcase.com" target="_blank" rel="noreferrer">Showwcase</a>
-        </p>
+      <div className="footer__inner">
+        <div className="footer__copyright">
+          <p>
+            &copy;
+            {' '}
+            { new Date().getFullYear() }
+            {' '}
+            Dimas Maulana Dwi Saputra
+          </p>
+        </div>
+        <div className="footer__design-inspired">
+          <p>
+            Built with
+            {' '}
+            <span className="footer__heart">React</span>
+            {' '}
+            &
+            {' '}
+            <a href="https://www.neobrutalism.dev" target="_blank" rel="noreferrer">Neobrutalism</a>
+          </p>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Pures/Footer/style.scss
+++ b/src/components/Pures/Footer/style.scss
@@ -15,6 +15,8 @@
     letter-spacing: 0.05em;
     margin-bottom: 16px;
     text-align: center;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 
   .footer__design-inspired {
@@ -33,6 +35,8 @@
       text-decoration: none;
       text-transform: uppercase;
       letter-spacing: 0.05em;
+      word-break: break-word;
+      overflow-wrap: break-word;
 
       &:hover {
         text-decoration: underline;
@@ -54,6 +58,22 @@
 
     .footer__design-inspired {
       text-align: right;
+    }
+  }
+}
+
+@media screen and (max-width: 799px) {
+  .footer {
+    padding: 24px 16px;
+
+    .footer__copyright {
+      font-size: 0.875rem;
+      margin-bottom: 12px;
+    }
+
+    .footer__design-inspired {
+      font-size: 0.75rem;
+      padding: 12px 16px;
     }
   }
 }

--- a/src/components/Pures/Footer/style.scss
+++ b/src/components/Pures/Footer/style.scss
@@ -3,18 +3,18 @@
   flex-direction: column;
   margin-top: 48px;
   padding: 32px;
-  background-color: var(--primary);
-  border: 3px solid var(--on-background-border);
-  box-shadow: 6px 6px 0 var(--shadow-color);
-  color: white;
-
+  /* Hapus background-color dan border yang berlebihan */
+  color: var(--on-surface);
+  /* Hapus box-shadow yang berat */
+  text-align: center;
+  border-bottom: 3px solid var(--on-background-border);
+  
   .footer__copyright {
     font-size: 1rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 16px;
-    text-align: center;
     word-break: break-word;
     overflow-wrap: break-word;
   }
@@ -22,13 +22,12 @@
   .footer__design-inspired {
     font-size: 0.875rem;
     text-align: center;
-    border: 3px solid white;
-    padding: 16px 24px;
-    border-radius: 0;
-    background-color: var(--surface);
+    /* Hapus border dan background yang berlebihan */
+    padding: 12px 24px;
+    background-color: transparent;
+    border: none;
     color: var(--on-background);
-    box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.3);
-
+    
     a {
       font-weight: 700;
       color: var(--primary);
@@ -37,9 +36,11 @@
       letter-spacing: 0.05em;
       word-break: break-word;
       overflow-wrap: break-word;
+      border-bottom: 3px solid transparent;
+      transition: border-color 0.2s ease;
 
       &:hover {
-        text-decoration: underline;
+        border-bottom-color: var(--primary);
       }
     }
   }
@@ -50,6 +51,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    padding: 32px 48px;
 
     .footer__copyright {
       text-align: left;
@@ -64,7 +66,7 @@
 
 @media screen and (max-width: 799px) {
   .footer {
-    padding: 24px 16px;
+    padding: 24px 20px;
 
     .footer__copyright {
       font-size: 0.875rem;
@@ -72,8 +74,7 @@
     }
 
     .footer__design-inspired {
-      font-size: 0.75rem;
-      padding: 12px 16px;
+      font-size: 0.8125rem;
     }
   }
 }

--- a/src/components/Pures/Footer/style.scss
+++ b/src/components/Pures/Footer/style.scss
@@ -1,42 +1,41 @@
 .footer {
-  display: flex;
-  flex-direction: column;
-  margin-top: 48px;
-  padding: 32px;
-  /* Hapus background-color dan border yang berlebihan */
-  color: var(--on-surface);
-  /* Hapus box-shadow yang berat */
-  text-align: center;
-  border-bottom: 3px solid var(--on-background-border);
-  
+  margin-top: 80px;
+  border-top: 2px solid var(--on-background-border);
+  background-color: var(--on-background);
+  color: var(--surface);
+
+  .footer__inner {
+    display: flex;
+    flex-direction: column;
+    padding: 32px;
+    text-align: center;
+    gap: 12px;
+  }
+
   .footer__copyright {
-    font-size: 1rem;
+    font-size: 0.9375rem;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: 16px;
-    word-break: break-word;
-    overflow-wrap: break-word;
+    letter-spacing: 0.08em;
   }
 
   .footer__design-inspired {
-    font-size: 0.875rem;
-    text-align: center;
-    /* Hapus border dan background yang berlebihan */
-    padding: 12px 24px;
-    background-color: transparent;
-    border: none;
-    color: var(--on-background);
-    
+    font-size: 0.8125rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.7;
+
+    .footer__heart {
+      font-weight: 700;
+      color: var(--primary);
+    }
+
     a {
       font-weight: 700;
       color: var(--primary);
       text-decoration: none;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      word-break: break-word;
-      overflow-wrap: break-word;
-      border-bottom: 3px solid transparent;
+      border-bottom: 2px solid transparent;
       transition: border-color 0.2s ease;
 
       &:hover {
@@ -48,33 +47,27 @@
 
 @media screen and (min-width: 800px) {
   .footer {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding: 32px 48px;
-
-    .footer__copyright {
-      text-align: left;
-      margin-bottom: 0;
-    }
-
-    .footer__design-inspired {
-      text-align: right;
+    .footer__inner {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      padding: 28px 48px;
     }
   }
 }
 
 @media screen and (max-width: 799px) {
   .footer {
-    padding: 24px 20px;
+    .footer__inner {
+      padding: 24px 20px;
+    }
 
     .footer__copyright {
-      font-size: 0.875rem;
-      margin-bottom: 12px;
+      font-size: 0.8125rem;
     }
 
     .footer__design-inspired {
-      font-size: 0.8125rem;
+      font-size: 0.75rem;
     }
   }
 }

--- a/src/components/Pures/Footer/style.scss
+++ b/src/components/Pures/Footer/style.scss
@@ -1,26 +1,42 @@
 .footer {
   display: flex;
   flex-direction: column;
-  margin-top: 32px;
-  align-items: center;
+  margin-top: 48px;
+  padding: 32px;
+  background-color: var(--primary);
+  border: 3px solid var(--on-background-border);
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  color: white;
 
   .footer__copyright {
-    font-size: 0.8rem;
-    font-weight: 300;
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
     margin-bottom: 16px;
+    text-align: center;
   }
 
   .footer__design-inspired {
-    font-size: 0.8rem;
+    font-size: 0.875rem;
     text-align: center;
-    border: 1px solid var(--on-background-grey);
-    padding: 16px;
-    border-radius: 8px;
+    border: 3px solid white;
+    padding: 16px 24px;
+    border-radius: 0;
+    background-color: var(--surface);
+    color: var(--on-background);
+    box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.3);
 
     a {
-      font-weight: bold;
-      color: var(--on-background);
+      font-weight: 700;
+      color: var(--primary);
       text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 }
@@ -30,5 +46,14 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+
+    .footer__copyright {
+      text-align: left;
+      margin-bottom: 0;
+    }
+
+    .footer__design-inspired {
+      text-align: right;
+    }
   }
 }

--- a/src/components/Pures/Navigation/style.scss
+++ b/src/components/Pures/Navigation/style.scss
@@ -13,6 +13,7 @@
       margin: 0 auto;
       display: grid;
       grid-template-columns: auto auto 1fr;
+      align-items: center;
       padding: 10px 16px;
       max-width: 1300px;
 
@@ -151,6 +152,7 @@
       .header__container {
         display: grid;
         grid-template-columns: 1fr auto;
+        align-items: center;
         gap: 20px;
 
         .header__drawer_button {

--- a/src/components/Pures/Navigation/style.scss
+++ b/src/components/Pures/Navigation/style.scss
@@ -4,8 +4,8 @@
   z-index: 1000;
 
   header {
-    border-bottom: 3px solid var(--on-background-border);
-    min-height: 70px;
+    border-bottom: 2px solid var(--on-background-border);
+    min-height: 64px;
     background-color: var(--surface);
     box-shadow: 0 4px 0 var(--shadow-color);
 
@@ -13,39 +13,34 @@
       margin: 0 auto;
       display: grid;
       grid-template-columns: auto auto 1fr;
-      padding: 12px;
-      max-width: 1400px;
+      padding: 10px 16px;
+      max-width: 1300px;
 
       .header__title {
         display: none;
-        font-size: 1.5rem;
-        font-weight: 700;
+        font-size: 1.25rem;
+        font-weight: 800;
         text-transform: uppercase;
         letter-spacing: 0.1em;
-        color: var(--primary);
-        text-shadow: 2px 2px 0 var(--shadow-color);
+        color: var(--on-background);
       }
 
       .header__drawer_button {
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: 50px;
-        min-width: 50px;
-        font-size: 28px;
+        min-height: 44px;
+        min-width: 44px;
+        font-size: 24px;
         background-color: var(--primary);
         color: white;
-        border: 3px solid var(--on-background-border);
+        border: 2px solid var(--on-background-border);
+        border-radius: var(--border-radius);
         cursor: pointer;
         box-shadow: 4px 4px 0 var(--shadow-color);
         transition: all 0.1s ease;
 
         &:hover {
-          transform: translate(2px, 2px);
-          box-shadow: 2px 2px 0 var(--shadow-color);
-        }
-
-        &:active {
           transform: translate(4px, 4px);
           box-shadow: none;
         }
@@ -61,28 +56,24 @@
         opacity: 0;
         min-height: 100vh;
         transition: all 0.3s ease-in-out;
-        border-right: 3px solid var(--on-background-border);
+        border-right: 2px solid var(--on-background-border);
 
         .header__navigation_drawer_close {
-          padding: 12px;
+          padding: 8px;
           cursor: pointer;
           background-color: var(--error);
           color: white;
-          border: 3px solid var(--on-background-border);
-          font-size: 32px;
+          border: 2px solid var(--on-background-border);
+          border-radius: var(--border-radius);
+          font-size: 28px;
           font-weight: 700;
-          min-width: 50px;
-          min-height: 50px;
+          min-width: 44px;
+          min-height: 44px;
           margin: 12px;
           box-shadow: 4px 4px 0 var(--shadow-color);
           transition: all 0.1s ease;
 
           &:hover {
-            transform: translate(2px, 2px);
-            box-shadow: 2px 2px 0 var(--shadow-color);
-          }
-
-          &:active {
             transform: translate(4px, 4px);
             box-shadow: none;
           }
@@ -103,18 +94,18 @@
               text-transform: uppercase;
               letter-spacing: 0.05em;
               border-bottom: 2px solid var(--on-background-border);
-              transition: all 0.1s ease;
+              transition: all 0.15s ease;
 
               &:hover {
                 background-color: var(--primary);
                 color: white;
-                padding-left: 50px;
+                padding-left: 56px;
               }
 
               &.active {
                 background-color: var(--primary);
                 color: white;
-                border-left: 6px solid var(--shadow-color);
+                border-left: 6px solid var(--on-background-border);
               }
             }
 
@@ -128,7 +119,8 @@
               text-decoration: none;
               color: var(--on-surface);
               background-color: var(--secondary);
-              border: 3px solid var(--on-background-border);
+              border: 2px solid var(--on-background-border);
+              border-radius: var(--border-radius);
               cursor: pointer;
               font-weight: 700;
               text-transform: uppercase;
@@ -137,11 +129,6 @@
               transition: all 0.1s ease;
 
               &:hover {
-                transform: translate(2px, 2px);
-                box-shadow: 2px 2px 0 var(--shadow-color);
-              }
-
-              &:active {
                 transform: translate(4px, 4px);
                 box-shadow: none;
               }
@@ -171,7 +158,8 @@
         }
 
         .header__title {
-          display: block;
+          display: flex;
+          align-items: center;
         }
 
         .header__navigation_drawer {
@@ -200,8 +188,9 @@
 
               a {
                 display: inline-block;
-                padding: 12px 24px;
-                border: 3px solid var(--on-background-border);
+                padding: 10px 20px;
+                border: 2px solid var(--on-background-border);
+                border-radius: var(--border-radius);
                 background-color: var(--surface);
                 color: var(--on-surface);
                 text-transform: uppercase;
@@ -211,15 +200,10 @@
                 transition: all 0.1s ease;
 
                 &:hover {
-                  transform: translate(2px, 2px);
-                  box-shadow: 1px 1px 0 var(--shadow-color);
-                  background-color: var(--primary);
-                  color: white;
-                }
-
-                &:active {
                   transform: translate(3px, 3px);
                   box-shadow: none;
+                  background-color: var(--primary);
+                  color: white;
                 }
 
                 &.active {
@@ -233,22 +217,18 @@
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                width: 50px;
-                height: 50px;
+                width: 44px;
+                height: 44px;
                 padding: 0;
-                min-width: 50px;
+                min-width: 44px;
                 margin: 0;
-                border: 3px solid var(--on-background-border);
+                border: 2px solid var(--on-background-border);
+                border-radius: var(--border-radius);
                 background-color: var(--secondary);
                 box-shadow: 3px 3px 0 var(--shadow-color);
                 transition: all 0.1s ease;
 
                 &:hover {
-                  transform: translate(2px, 2px);
-                  box-shadow: 1px 1px 0 var(--shadow-color);
-                }
-
-                &:active {
                   transform: translate(3px, 3px);
                   box-shadow: none;
                 }

--- a/src/components/Pures/Navigation/style.scss
+++ b/src/components/Pures/Navigation/style.scss
@@ -1,34 +1,54 @@
 .header {
   position: sticky;
   top: 0;
+  z-index: 1000;
 
   header {
-    border-bottom: 1px solid var(--on-background-border);
-    min-height: 55px;
-    background-color: var(--background);
+    border-bottom: 3px solid var(--on-background-border);
+    min-height: 70px;
+    background-color: var(--surface);
+    box-shadow: 0 4px 0 var(--shadow-color);
 
     .header__container {
       margin: 0 auto;
       display: grid;
       grid-template-columns: auto auto 1fr;
-      padding: 4px 12px;
-      max-width: 1200px;
+      padding: 12px;
+      max-width: 1400px;
 
       .header__title {
         display: none;
+        font-size: 1.5rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--primary);
+        text-shadow: 2px 2px 0 var(--shadow-color);
       }
 
       .header__drawer_button {
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: 44px;
-        min-width: 44px;
-        font-size: 24px;
-        background-color: transparent;
-        border: 0;
-        color: var(--on-background);
+        min-height: 50px;
+        min-width: 50px;
+        font-size: 28px;
+        background-color: var(--primary);
+        color: white;
+        border: 3px solid var(--on-background-border);
         cursor: pointer;
+        box-shadow: 4px 4px 0 var(--shadow-color);
+        transition: all 0.1s ease;
+
+        &:hover {
+          transform: translate(2px, 2px);
+          box-shadow: 2px 2px 0 var(--shadow-color);
+        }
+
+        &:active {
+          transform: translate(4px, 4px);
+          box-shadow: none;
+        }
       }
 
       .header__navigation_drawer {
@@ -37,51 +57,94 @@
         left: 0;
         transform: translateX(-100%);
         min-width: 100vw;
-        background-color: var(--background);
+        background-color: var(--surface);
         opacity: 0;
         min-height: 100vh;
         transition: all 0.3s ease-in-out;
+        border-right: 3px solid var(--on-background-border);
 
         .header__navigation_drawer_close {
-          padding: 8px;
+          padding: 12px;
           cursor: pointer;
-          background-color: transparent;
-          border: none;
+          background-color: var(--error);
+          color: white;
+          border: 3px solid var(--on-background-border);
           font-size: 32px;
-          font-weight: lighter;
-          min-width: 44px;
-          min-height: 44px;
-          margin-left: 8px;
-          color: var(--on-background);
+          font-weight: 700;
+          min-width: 50px;
+          min-height: 50px;
+          margin: 12px;
+          box-shadow: 4px 4px 0 var(--shadow-color);
+          transition: all 0.1s ease;
+
+          &:hover {
+            transform: translate(2px, 2px);
+            box-shadow: 2px 2px 0 var(--shadow-color);
+          }
+
+          &:active {
+            transform: translate(4px, 4px);
+            box-shadow: none;
+          }
         }
 
         ul {
+          margin-top: 24px;
 
           li {
             display: block;
 
             a {
               display: block;
-              padding: 16px 32px;
+              padding: 20px 40px;
               text-decoration: none;
-              color: var(--on-background);
-            }
+              color: var(--on-surface);
+              font-weight: 700;
+              text-transform: uppercase;
+              letter-spacing: 0.05em;
+              border-bottom: 2px solid var(--on-background-border);
+              transition: all 0.1s ease;
 
-            .active {
-              font-weight: bold;
+              &:hover {
+                background-color: var(--primary);
+                color: white;
+                padding-left: 50px;
+              }
+
+              &.active {
+                background-color: var(--primary);
+                color: white;
+                border-left: 6px solid var(--shadow-color);
+              }
             }
 
             button {
               display: block;
               text-align: left;
-              font-size: 24px;
-              width: 100%;
-              padding: 16px 32px;
+              font-size: 28px;
+              width: calc(100% - 24px);
+              margin: 12px;
+              padding: 20px 40px;
               text-decoration: none;
-              color: var(--on-background);
-              background-color: transparent;
-              border: 0;
+              color: var(--on-surface);
+              background-color: var(--secondary);
+              border: 3px solid var(--on-background-border);
               cursor: pointer;
+              font-weight: 700;
+              text-transform: uppercase;
+              letter-spacing: 0.05em;
+              box-shadow: 4px 4px 0 var(--shadow-color);
+              transition: all 0.1s ease;
+
+              &:hover {
+                transform: translate(2px, 2px);
+                box-shadow: 2px 2px 0 var(--shadow-color);
+              }
+
+              &:active {
+                transform: translate(4px, 4px);
+                box-shadow: none;
+              }
             }
           }
         }
@@ -101,6 +164,7 @@
       .header__container {
         display: grid;
         grid-template-columns: 1fr auto;
+        gap: 20px;
 
         .header__drawer_button {
           display: none;
@@ -108,9 +172,6 @@
 
         .header__title {
           display: block;
-          font-size: 19px;
-          margin: auto 0;
-          user-select: none;
         }
 
         .header__navigation_drawer {
@@ -121,6 +182,7 @@
           transition: none;
           transform: translateX(0);
           text-align: left;
+          border: none;
 
           .header__navigation_drawer_close {
             display: none;
@@ -130,19 +192,66 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            margin-top: 0;
+            gap: 8px;
 
             li {
               display: inline;
 
               a {
                 display: inline-block;
+                padding: 12px 24px;
+                border: 3px solid var(--on-background-border);
+                background-color: var(--surface);
+                color: var(--on-surface);
+                text-transform: uppercase;
+                font-weight: 700;
+                letter-spacing: 0.05em;
+                box-shadow: 3px 3px 0 var(--shadow-color);
+                transition: all 0.1s ease;
+
+                &:hover {
+                  transform: translate(2px, 2px);
+                  box-shadow: 1px 1px 0 var(--shadow-color);
+                  background-color: var(--primary);
+                  color: white;
+                }
+
+                &:active {
+                  transform: translate(3px, 3px);
+                  box-shadow: none;
+                }
+
+                &.active {
+                  background-color: var(--primary);
+                  color: white;
+                  box-shadow: 3px 3px 0 var(--shadow-color);
+                }
               }
 
               button {
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                width: auto;
+                width: 50px;
+                height: 50px;
+                padding: 0;
+                min-width: 50px;
+                margin: 0;
+                border: 3px solid var(--on-background-border);
+                background-color: var(--secondary);
+                box-shadow: 3px 3px 0 var(--shadow-color);
+                transition: all 0.1s ease;
+
+                &:hover {
+                  transform: translate(2px, 2px);
+                  box-shadow: 1px 1px 0 var(--shadow-color);
+                }
+
+                &:active {
+                  transform: translate(3px, 3px);
+                  box-shadow: none;
+                }
               }
             }
           }

--- a/src/components/Pures/Notebooks/style.scss
+++ b/src/components/Pures/Notebooks/style.scss
@@ -1,27 +1,42 @@
 .notebooks {
-  margin-top: 16px;
+  margin-top: 24px;
 
   .notebook-item {
     display: flex;
     align-items: center;
-    padding: 16px 0;
-    border-bottom: 2px dashed var(--on-background-grey);
+    padding: 16px 20px;
+    margin-bottom: 12px;
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 3px 3px 0 var(--shadow-color);
+    transition: all 0.1s ease;
+
+    &:hover {
+      transform: translate(3px, 3px);
+      box-shadow: none;
+      border-color: var(--primary);
+    }
 
     a {
       display: inline-block;
       flex: 1;
-      font-size: 14px;
+      font-size: 0.9375rem;
+      font-weight: 600;
       color: var(--on-background);
       text-decoration: none;
     }
 
-    a:hover {
-      text-decoration: underline;
-    }
-
     span {
-      font-size: 14px;
+      font-size: 0.8125rem;
+      font-weight: 500;
       color: var(--on-background-grey);
+      padding: 4px 10px;
+      background-color: var(--background);
+      border: 2px solid var(--on-background-border);
+      border-radius: var(--border-radius);
+      white-space: nowrap;
+      margin-left: 12px;
     }
   }
 }
@@ -29,9 +44,12 @@
 @media screen and (min-width: 600px) {
   .notebooks {
     .notebook-item {
+      a {
+        font-size: 1.0625rem;
+      }
 
-      a, span {
-        font-size: 16px;
+      span {
+        font-size: 0.875rem;
       }
     }
   }

--- a/src/components/Pures/PersonalInformation/index.jsx
+++ b/src/components/Pures/PersonalInformation/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { personalInformation } from '../../../content';
 
 import './style.scss';
-import Tags from '../Tags';
 import SocialMedias from '../SocialMedias';
 
 function PersonalInformation() {
@@ -21,59 +20,60 @@ function PersonalInformation() {
   } = currentJob;
   return (
     <header className="personal-information">
-      <img
-        className="personal-information__image-profile"
-        src={pictureUrl}
-        alt={`${name} profile`}
-      />
-      <h2 className="personal-information__name">{name}</h2>
-      <div className="personal-information__mini_info">
-        <div>
-          <span>{`@${mention}`}</span>
-        </div>
-        <div>
-          <span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-              <circle cx="12" cy="10" r="3" />
-            </svg>
-            {location}
-          </span>
-        </div>
-        <div>
-          <span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="16 18 22 12 16 6" />
-              <polyline points="8 6 2 12 8 18" />
-            </svg>
-            {`${role} at `}
-            {' '}
-            <strong>{at}</strong>
-          </span>
+      <div className="personal-information__hero">
+        <img
+          className="personal-information__image-profile"
+          src={pictureUrl}
+          alt={`${name} profile`}
+        />
+        <div className="personal-information__intro">
+          <span className="personal-information__greeting">{`@${mention}`}</span>
+          <h2 className="personal-information__name">{name}</h2>
+          <div className="personal-information__mini_info">
+            <div>
+              <span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                {location}
+              </span>
+            </div>
+            <div>
+              <span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="16 18 22 12 16 6" />
+                  <polyline points="8 6 2 12 8 18" />
+                </svg>
+                {`${role} at `}
+                {' '}
+                <strong>{at}</strong>
+              </span>
+            </div>
+          </div>
         </div>
       </div>
       <p className="personal-information__description">{description}</p>
-      <Tags />
       <SocialMedias />
     </header>
   );

--- a/src/components/Pures/PersonalInformation/style.scss
+++ b/src/components/Pures/PersonalInformation/style.scss
@@ -1,29 +1,31 @@
 .personal-information {
-  background-color: var(--surface);
-  border: 3px solid var(--on-background-border);
-  box-shadow: 6px 6px 0 var(--shadow-color);
-  padding: 32px;
+  /* Hapus nesting - jadi flat layout */
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
   text-align: center;
-  overflow: hidden;
+  margin-bottom: 32px;
 
   .personal-information__image-profile {
-    width: 180px;
-    height: 180px;
+    width: 160px;
+    height: 160px;
     border-radius: 0;
     margin: 0 0 24px 0;
     border: 4px solid var(--primary);
     box-shadow: 4px 4px 0 var(--shadow-color);
+    display: block;
     max-width: 100%;
   }
 
   .personal-information__name {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: 2rem;
+    font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.1em;
     margin: 0 0 24px 0;
     color: var(--primary);
-    text-shadow: 3px 3px 0 var(--shadow-color);
+    text-shadow: 2px 2px 0 var(--shadow-color);
     word-break: break-word;
     overflow-wrap: break-word;
   }
@@ -33,7 +35,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 16px;
+    gap: 12px;
 
     div {
       display: inline-block;
@@ -42,26 +44,26 @@
       span {
         display: inline-flex;
         align-items: center;
-        padding: 12px 20px;
+        padding: 10px 16px;
         background-color: var(--primary);
         color: white;
-        border: 3px solid var(--on-background-border);
-        box-shadow: 3px 3px 0 var(--shadow-color);
+        border: 2px solid var(--on-background-border);
+        box-shadow: 2px 2px 0 var(--shadow-color);
         font-weight: 700;
         text-transform: uppercase;
-        letter-spacing: 0.05em;
+        letter-spacing: 0.03em;
         transition: all 0.1s ease;
-        font-size: 0.875rem;
+        font-size: 0.8125rem;
 
         &:hover {
-          transform: translate(2px, 2px);
+          transform: translate(1px, 1px);
           box-shadow: 1px 1px 0 var(--shadow-color);
         }
 
         svg {
-          margin-right: 8px;
-          width: 18px;
-          height: 18px;
+          margin-right: 6px;
+          width: 16px;
+          height: 16px;
         }
 
         strong {
@@ -76,34 +78,37 @@
 
   .personal-information__description {
     margin-top: 24px;
-    font-size: 1.125rem;
-    line-height: 1.75;
+    font-size: 1rem;
+    line-height: 1.6;
     color: var(--on-surface);
     padding: 20px;
-    background-color: var(--background);
-    border: 3px solid var(--on-background-border);
-    box-shadow: 4px 4px 0 var(--shadow-color);
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    box-shadow: 3px 3px 0 var(--shadow-color);
     text-align: left;
     word-break: break-word;
     overflow-wrap: break-word;
+    /* Hapus corner marker dan border extra */
   }
 }
 
 @media screen and (min-width: 600px) {
   .personal-information {
     .personal-information__name {
-      font-size: 3rem;
+      font-size: 2.5rem;
     }
 
     .personal-information__description {
-      font-size: 1.25rem;
+      font-size: 1.0625rem;
+      padding: 24px 32px;
     }
   }
 }
 
 @media screen and (max-width: 599px) {
   .personal-information {
-    padding: 20px 16px;
+    padding: 0 16px;
+    margin-bottom: 24px;
 
     .personal-information__image-profile {
       width: 120px;
@@ -128,9 +133,11 @@
         width: 100%;
 
         span {
-          padding: 10px 16px;
+          padding: 8px 12px;
           font-size: 0.75rem;
           justify-content: center;
+          border-width: 2px;
+          box-shadow: 2px 2px 0 var(--shadow-color);
         }
       }
     }
@@ -138,7 +145,7 @@
     .personal-information__description {
       margin-top: 16px;
       font-size: 0.875rem;
-      padding: 12px 16px;
+      padding: 16px 20px;
     }
   }
 }

--- a/src/components/Pures/PersonalInformation/style.scss
+++ b/src/components/Pures/PersonalInformation/style.scss
@@ -4,6 +4,7 @@
   box-shadow: 6px 6px 0 var(--shadow-color);
   padding: 32px;
   text-align: center;
+  overflow: hidden;
 
   .personal-information__image-profile {
     width: 180px;
@@ -12,6 +13,7 @@
     margin: 0 0 24px 0;
     border: 4px solid var(--primary);
     box-shadow: 4px 4px 0 var(--shadow-color);
+    max-width: 100%;
   }
 
   .personal-information__name {
@@ -22,6 +24,8 @@
     margin: 0 0 24px 0;
     color: var(--primary);
     text-shadow: 3px 3px 0 var(--shadow-color);
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 
   .personal-information__mini_info {
@@ -47,6 +51,7 @@
         text-transform: uppercase;
         letter-spacing: 0.05em;
         transition: all 0.1s ease;
+        font-size: 0.875rem;
 
         &:hover {
           transform: translate(2px, 2px);
@@ -62,6 +67,8 @@
         strong {
           margin-left: 4px;
           text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
+          word-break: break-word;
+          overflow-wrap: break-word;
         }
       }
     }
@@ -77,6 +84,8 @@
     border: 3px solid var(--on-background-border);
     box-shadow: 4px 4px 0 var(--shadow-color);
     text-align: left;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 }
 
@@ -88,6 +97,48 @@
 
     .personal-information__description {
       font-size: 1.25rem;
+    }
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .personal-information {
+    padding: 20px 16px;
+
+    .personal-information__image-profile {
+      width: 120px;
+      height: 120px;
+      margin: 0 0 16px 0;
+      border-width: 3px;
+    }
+
+    .personal-information__name {
+      font-size: 1.5rem;
+      margin: 0 0 16px 0;
+      letter-spacing: 0.05em;
+    }
+
+    .personal-information__mini_info {
+      margin-bottom: 16px;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+
+      div {
+        width: 100%;
+
+        span {
+          padding: 10px 16px;
+          font-size: 0.75rem;
+          justify-content: center;
+        }
+      }
+    }
+
+    .personal-information__description {
+      margin-top: 16px;
+      font-size: 0.875rem;
+      padding: 12px 16px;
     }
   }
 }

--- a/src/components/Pures/PersonalInformation/style.scss
+++ b/src/components/Pures/PersonalInformation/style.scss
@@ -1,41 +1,58 @@
 .personal-information {
-  /* Hapus nesting - jadi flat layout */
   background-color: transparent;
   border: none;
   box-shadow: none;
   padding: 0;
-  text-align: center;
-  margin-bottom: 32px;
+  margin-bottom: 48px;
+
+  .personal-information__hero {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 40px;
+    align-items: start;
+    margin-bottom: 32px;
+  }
 
   .personal-information__image-profile {
-    width: 160px;
-    height: 160px;
-    border-radius: 0;
-    margin: 0 0 24px 0;
-    border: 4px solid var(--primary);
-    box-shadow: 4px 4px 0 var(--shadow-color);
+    width: 180px;
+    height: 180px;
+    border-radius: var(--border-radius);
+    border: 2px solid var(--on-background-border);
+    box-shadow: 6px 6px 0 var(--shadow-color);
     display: block;
-    max-width: 100%;
+    object-fit: cover;
+  }
+
+  .personal-information__intro {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .personal-information__greeting {
+    font-size: 1rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--on-background-grey);
+    margin-bottom: 8px;
   }
 
   .personal-information__name {
-    font-size: 2rem;
+    font-size: 2.75rem;
     font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    margin: 0 0 24px 0;
-    color: var(--primary);
-    text-shadow: 2px 2px 0 var(--shadow-color);
-    word-break: break-word;
-    overflow-wrap: break-word;
+    letter-spacing: 0.06em;
+    margin: 0 0 16px 0;
+    color: var(--on-background);
+    line-height: 1.05;
   }
 
   .personal-information__mini_info {
-    margin-bottom: 24px;
+    margin-bottom: 0;
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
-    gap: 12px;
+    gap: 10px;
 
     div {
       display: inline-block;
@@ -44,11 +61,12 @@
       span {
         display: inline-flex;
         align-items: center;
-        padding: 10px 16px;
+        padding: 8px 14px;
         background-color: var(--primary);
         color: white;
         border: 2px solid var(--on-background-border);
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        border-radius: var(--border-radius);
+        box-shadow: 3px 3px 0 var(--shadow-color);
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.03em;
@@ -56,8 +74,8 @@
         font-size: 0.8125rem;
 
         &:hover {
-          transform: translate(1px, 1px);
-          box-shadow: 1px 1px 0 var(--shadow-color);
+          transform: translate(3px, 3px);
+          box-shadow: none;
         }
 
         svg {
@@ -68,63 +86,70 @@
 
         strong {
           margin-left: 4px;
-          text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
-          word-break: break-word;
-          overflow-wrap: break-word;
         }
       }
     }
   }
 
   .personal-information__description {
-    margin-top: 24px;
-    font-size: 1rem;
-    line-height: 1.6;
+    margin-top: 0;
+    font-size: 1.0625rem;
+    line-height: 1.7;
     color: var(--on-surface);
-    padding: 20px;
+    padding: 24px 28px;
     background-color: var(--surface);
     border: 2px solid var(--on-background-border);
-    box-shadow: 3px 3px 0 var(--shadow-color);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
     text-align: left;
     word-break: break-word;
     overflow-wrap: break-word;
-    /* Hapus corner marker dan border extra */
+    position: relative;
   }
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (min-width: 768px) {
   .personal-information {
     .personal-information__name {
-      font-size: 2.5rem;
+      font-size: 3.25rem;
     }
 
     .personal-information__description {
-      font-size: 1.0625rem;
-      padding: 24px 32px;
+      padding: 28px 36px;
     }
   }
 }
 
-@media screen and (max-width: 599px) {
+@media screen and (max-width: 767px) {
   .personal-information {
-    padding: 0 16px;
-    margin-bottom: 24px;
+    padding: 0;
+    margin-bottom: 32px;
+
+    .personal-information__hero {
+      grid-template-columns: 1fr;
+      gap: 20px;
+      text-align: center;
+    }
 
     .personal-information__image-profile {
       width: 120px;
       height: 120px;
-      margin: 0 0 16px 0;
-      border-width: 3px;
+      margin: 0 auto;
+      box-shadow: 4px 4px 0 var(--shadow-color);
+    }
+
+    .personal-information__intro {
+      align-items: center;
     }
 
     .personal-information__name {
-      font-size: 1.5rem;
-      margin: 0 0 16px 0;
-      letter-spacing: 0.05em;
+      font-size: 1.75rem;
+      margin: 0 0 12px 0;
+      text-align: center;
     }
 
     .personal-information__mini_info {
-      margin-bottom: 16px;
+      justify-content: center;
       gap: 8px;
       flex-direction: column;
       align-items: stretch;
@@ -136,15 +161,13 @@
           padding: 8px 12px;
           font-size: 0.75rem;
           justify-content: center;
-          border-width: 2px;
-          box-shadow: 2px 2px 0 var(--shadow-color);
+          width: 100%;
         }
       }
     }
 
     .personal-information__description {
-      margin-top: 16px;
-      font-size: 0.875rem;
+      font-size: 0.9375rem;
       padding: 16px 20px;
     }
   }

--- a/src/components/Pures/PersonalInformation/style.scss
+++ b/src/components/Pures/PersonalInformation/style.scss
@@ -1,65 +1,93 @@
 .personal-information {
+  background-color: var(--surface);
+  border: 3px solid var(--on-background-border);
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  padding: 32px;
+  text-align: center;
 
   .personal-information__image-profile {
-    width: 160px;
-    height: 160px;
-    border-radius: 50%;
-    margin: 8px 0;
+    width: 180px;
+    height: 180px;
+    border-radius: 0;
+    margin: 0 0 24px 0;
+    border: 4px solid var(--primary);
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .personal-information__name {
-    font-size: 20px;
-    margin: 8px 0 0 0;
+    font-size: 2.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin: 0 0 24px 0;
+    color: var(--primary);
+    text-shadow: 3px 3px 0 var(--shadow-color);
   }
 
   .personal-information__mini_info {
-    margin-bottom: 12px;
-    display: inline-block;
-    font-size: 12px;
+    margin-bottom: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
 
     div {
       display: inline-block;
-      margin-top: 8px;
+      margin: 0;
 
       span {
-        display: flex;
-        flex-wrap: nowrap;
+        display: inline-flex;
         align-items: center;
-        margin-right: 12px;
+        padding: 12px 20px;
+        background-color: var(--primary);
+        color: white;
+        border: 3px solid var(--on-background-border);
+        box-shadow: 3px 3px 0 var(--shadow-color);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        transition: all 0.1s ease;
+
+        &:hover {
+          transform: translate(2px, 2px);
+          box-shadow: 1px 1px 0 var(--shadow-color);
+        }
 
         svg {
-          margin: 0 4px;
-          width: 13px;
-          height: 13px;
+          margin-right: 8px;
+          width: 18px;
+          height: 18px;
         }
 
         strong {
           margin-left: 4px;
+          text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
         }
       }
     }
   }
 
   .personal-information__description {
-    margin-top: 12px;
-    font-size: 14px;
+    margin-top: 24px;
+    font-size: 1.125rem;
     line-height: 1.75;
+    color: var(--on-surface);
+    padding: 20px;
+    background-color: var(--background);
+    border: 3px solid var(--on-background-border);
+    box-shadow: 4px 4px 0 var(--shadow-color);
+    text-align: left;
   }
 }
 
 @media screen and (min-width: 600px) {
   .personal-information {
-
     .personal-information__name {
-      font-size: 30px;
-    }
-
-    .personal-information__mini_info {
-      font-size: 14px;
+      font-size: 3rem;
     }
 
     .personal-information__description {
-      font-size: 18px;
+      font-size: 1.25rem;
     }
   }
 }

--- a/src/components/Pures/SocialMedias/style.scss
+++ b/src/components/Pures/SocialMedias/style.scss
@@ -1,14 +1,36 @@
 .social-medias {
   margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
 
   li {
     display: inline-block;
 
     a {
-      display: inline-block;
-      margin-right: 12px;
-      color: var(--on-background);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 50px;
+      height: 50px;
+      background-color: var(--primary);
+      color: white;
+      border: 3px solid var(--on-background-border);
+      box-shadow: 4px 4px 0 var(--shadow-color);
       font-size: 24px;
+      transition: all 0.1s ease;
+
+      &:hover {
+        transform: translate(2px, 2px);
+        box-shadow: 2px 2px 0 var(--shadow-color);
+        background-color: var(--primary-variant);
+      }
+
+      &:active {
+        transform: translate(4px, 4px);
+        box-shadow: none;
+      }
     }
   }
 }

--- a/src/components/Pures/SocialMedias/style.scss
+++ b/src/components/Pures/SocialMedias/style.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  justify-content: center;
+  justify-content: flex-start;
 
   li {
     display: inline-block;
@@ -12,25 +12,28 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 50px;
-      height: 50px;
-      background-color: var(--primary);
-      color: white;
-      border: 3px solid var(--on-background-border);
+      width: 48px;
+      height: 48px;
+      background-color: var(--on-background);
+      color: var(--surface);
+      border: 2px solid var(--on-background-border);
+      border-radius: var(--border-radius);
       box-shadow: 4px 4px 0 var(--shadow-color);
-      font-size: 24px;
+      font-size: 22px;
       transition: all 0.1s ease;
 
       &:hover {
-        transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color);
-        background-color: var(--primary-variant);
-      }
-
-      &:active {
         transform: translate(4px, 4px);
         box-shadow: none;
+        background-color: var(--primary);
+        color: white;
       }
     }
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .social-medias {
+    justify-content: center;
   }
 }

--- a/src/components/Pures/Tag/style.scss
+++ b/src/components/Pures/Tag/style.scss
@@ -1,27 +1,48 @@
 .tag {
   display: inline-block;
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  margin: 16px 8px 4px 0;
-  border-radius: 12px;
-  font-size: 16px;
+  padding: 12px 20px;
+  border: 3px solid var(--on-background-border);
+  margin: 0;
+  border-radius: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: var(--secondary);
+  color: white;
+  box-shadow: 4px 4px 0 var(--shadow-color);
+  transition: all 0.1s ease;
+  cursor: default;
+
+  &:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0 var(--shadow-color);
+  }
   
   div {
     display: flex;
     align-items: center;
+    gap: 8px;
 
     * {
       display: inline-block;
     }
   
     svg {
-      margin-right: 8px;
+      width: 20px;
+      height: 20px;
+      color: white;
+    }
+
+    .tag__name {
+      margin: 0;
+      font-weight: inherit;
     }
   }
 }
 
 @media screen and (min-width: 600px){
   .tag {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 }

--- a/src/components/Pures/Tag/style.scss
+++ b/src/components/Pures/Tag/style.scss
@@ -1,24 +1,24 @@
 .tag {
   display: inline-block;
-  padding: 12px 20px;
-  border: 3px solid var(--on-background-border);
+  padding: 10px 18px;
+  border: 2px solid var(--on-background-border);
   margin: 0;
-  border-radius: 0;
-  font-size: 1rem;
+  border-radius: var(--border-radius);
+  font-size: 0.9375rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   background-color: var(--secondary);
-  color: white;
-  box-shadow: 4px 4px 0 var(--shadow-color);
+  color: #000000;
+  box-shadow: 3px 3px 0 var(--shadow-color);
   transition: all 0.1s ease;
   cursor: default;
 
   &:hover {
-    transform: translate(2px, 2px);
-    box-shadow: 2px 2px 0 var(--shadow-color);
+    transform: translate(3px, 3px);
+    box-shadow: none;
   }
-  
+
   div {
     display: flex;
     align-items: center;
@@ -27,11 +27,11 @@
     * {
       display: inline-block;
     }
-  
+
     svg {
-      width: 20px;
-      height: 20px;
-      color: white;
+      width: 18px;
+      height: 18px;
+      color: #000000;
     }
 
     .tag__name {
@@ -41,8 +41,8 @@
   }
 }
 
-@media screen and (min-width: 600px){
+@media screen and (min-width: 600px) {
   .tag {
-    font-size: 1.125rem;
+    font-size: 1rem;
   }
 }

--- a/src/components/Pures/Tags/style.scss
+++ b/src/components/Pures/Tags/style.scss
@@ -1,7 +1,13 @@
 .tags {
-  margin-top: 16px;
+  margin-top: 20px;
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  justify-content: center;
+  gap: 10px;
+  justify-content: flex-start;
+}
+
+@media screen and (max-width: 767px) {
+  .tags {
+    justify-content: center;
+  }
 }

--- a/src/components/Pures/Tags/style.scss
+++ b/src/components/Pures/Tags/style.scss
@@ -1,3 +1,7 @@
 .tags {
-  margin-top: 8px;
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
 }

--- a/src/components/Pures/TechStack/index.jsx
+++ b/src/components/Pures/TechStack/index.jsx
@@ -3,27 +3,47 @@ import { techStack } from '../../../content';
 
 import './style.scss';
 
+const accentColors = [
+  '#4A90FF', // blue
+  '#00E676', // green
+  '#FF6B35', // orange
+  '#FFBE0B', // yellow
+  '#E040FB', // purple
+  '#00BCD4', // cyan
+  '#FF4081', // pink
+  '#7C4DFF', // deep purple
+];
+
+// Flatten all tech items with their category
+const allTechItems = Object.entries(techStack).flatMap(([category, items]) => items.map((item) => ({
+  ...item,
+  category,
+})));
+
 function TechStack() {
   return (
     <div className="tech-stack">
       <h3 className="tech-stack__title">Tech Stack</h3>
-      <div className="tech-stack__stack__list">
-        {
-        Object.keys(techStack)
-          .map((key) => (
-            <div key={key} className="tech-stack__stack">
-              <h4>{key}</h4>
-              {techStack[key].map(({ name, icon }) => (
-                <div key={name} className="tech-stack__stack__item">
-                  <img src={icon} alt={name} />
-                  <p>
-                    {name}
-                  </p>
-                </div>
-              ))}
+
+      <div className="tech-stack__grid">
+        {allTechItems.map(({ name, icon, category }, index) => {
+          const color = accentColors[index % accentColors.length];
+          return (
+            <div
+              key={name}
+              className="tech-stack__card"
+              style={{ '--accent': color }}
+            >
+              <div className="tech-stack__card-icon">
+                <img src={icon} alt={name} />
+              </div>
+              <div className="tech-stack__card-info">
+                <p className="tech-stack__card-name">{name}</p>
+                <span className="tech-stack__card-category">{category}</span>
+              </div>
             </div>
-          ))
-      }
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Pures/TechStack/style.scss
+++ b/src/components/Pures/TechStack/style.scss
@@ -17,67 +17,113 @@
     box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
-  .tech-stack__stack__list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 24px;
+  /* Sticker board grid */
+  .tech-stack__grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+  }
 
-    .tech-stack__stack {
-      margin-top: 0;
+  .tech-stack__card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 18px;
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    border-left: 5px solid var(--accent);
+    box-shadow: 3px 3px 0 var(--shadow-color);
+    transition: all 0.15s ease;
+    cursor: default;
+    flex-shrink: 0;
 
-      h4 {
-        font-size: 0.8125rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        margin-bottom: 12px;
-        color: var(--on-background);
-        padding: 6px 12px;
-        background-color: var(--warning);
-        border: 2px solid var(--on-background-border);
-        border-radius: var(--border-radius);
-        display: inline-block;
-        box-shadow: 3px 3px 0 var(--shadow-color);
+    &:hover {
+      transform: translate(3px, 3px);
+      box-shadow: none;
+      background-color: var(--accent);
+      border-left-color: var(--on-background-border);
+
+      .tech-stack__card-name {
+        color: white;
       }
 
-      .tech-stack__stack__item {
-        display: flex;
-        align-items: center;
-        margin-top: 10px;
-        padding: 14px 16px;
-        background-color: var(--surface);
-        border: 2px solid var(--on-background-border);
-        border-radius: var(--border-radius);
-        box-shadow: 3px 3px 0 var(--shadow-color);
-        transition: all 0.1s ease;
+      .tech-stack__card-category {
+        background-color: rgba(0, 0, 0, 0.25);
+        color: white;
+        border-color: transparent;
+      }
 
-        &:hover {
-          transform: translate(3px, 3px);
-          box-shadow: none;
-          background-color: var(--primary);
-          color: white;
-
-          p {
-            color: white;
-          }
-        }
-
-        img {
-          width: 28px;
-          height: 28px;
-          margin-right: 14px;
-          flex-shrink: 0;
-        }
-
-        p {
-          font-size: 1rem;
-          font-weight: 600;
-          color: var(--on-surface);
-          margin: 0;
-          transition: color 0.1s ease;
-        }
+      .tech-stack__card-icon img {
+        filter: brightness(0) invert(1);
       }
     }
+
+    /* Variasi: setiap card ke-5 agak lebih besar */
+    &:nth-child(5n) {
+      padding: 16px 24px;
+
+      .tech-stack__card-icon img {
+        width: 36px;
+        height: 36px;
+      }
+
+      .tech-stack__card-name {
+        font-size: 1.125rem;
+      }
+    }
+
+    /* Variasi: setiap card ke-7 punya top border instead of left */
+    &:nth-child(7n) {
+      border-left: 2px solid var(--on-background-border);
+      border-top: 5px solid var(--accent);
+
+      &:hover {
+        border-top-color: var(--on-background-border);
+      }
+    }
+  }
+
+  .tech-stack__card-icon {
+    flex-shrink: 0;
+
+    img {
+      width: 28px;
+      height: 28px;
+      display: block;
+      transition: filter 0.15s ease;
+    }
+  }
+
+  .tech-stack__card-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .tech-stack__card-name {
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: var(--on-surface);
+    margin: 0;
+    white-space: nowrap;
+    transition: color 0.15s ease;
+  }
+
+  .tech-stack__card-category {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--on-background-grey);
+    background-color: var(--background);
+    border: 1px solid var(--on-background-border);
+    border-radius: 3px;
+    padding: 2px 6px;
+    display: inline-block;
+    align-self: flex-start;
+    transition: all 0.15s ease;
   }
 }
 
@@ -99,31 +145,39 @@
       margin-bottom: 20px;
     }
 
-    .tech-stack__stack__list {
-      grid-template-columns: 1fr;
-      gap: 16px;
+    .tech-stack__grid {
+      gap: 10px;
+    }
 
-      .tech-stack__stack {
-        h4 {
-          font-size: 0.75rem;
-          padding: 5px 10px;
-          margin-bottom: 8px;
+    .tech-stack__card {
+      padding: 10px 14px;
+      gap: 10px;
+
+      &:nth-child(5n) {
+        padding: 10px 14px;
+
+        .tech-stack__card-icon img {
+          width: 28px;
+          height: 28px;
         }
 
-        .tech-stack__stack__item {
-          padding: 12px;
-
-          img {
-            width: 24px;
-            height: 24px;
-            margin-right: 12px;
-          }
-
-          p {
-            font-size: 0.9375rem;
-          }
+        .tech-stack__card-name {
+          font-size: 0.875rem;
         }
       }
+    }
+
+    .tech-stack__card-icon img {
+      width: 24px;
+      height: 24px;
+    }
+
+    .tech-stack__card-name {
+      font-size: 0.8125rem;
+    }
+
+    .tech-stack__card-category {
+      font-size: 0.5625rem;
     }
   }
 }

--- a/src/components/Pures/TechStack/style.scss
+++ b/src/components/Pures/TechStack/style.scss
@@ -1,42 +1,67 @@
 .tech-stack {
   margin-top: 48px;
   padding-bottom: 48px;
-  border-bottom: 1px var(--on-background-border) solid;
+  border-bottom: 3px solid var(--on-background-border);
+  background-color: var(--surface);
+  border: 3px solid var(--on-background-border);
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  padding: 32px;
 
   .tech-stack__title {
-    font-size: 16px;
-    font-weight: bold;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--primary);
+    margin-bottom: 24px;
+    text-shadow: 2px 2px 0 var(--shadow-color);
   }
 
   .tech-stack__stack__list {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    grid-gap: 14px;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 24px;
 
     .tech-stack__stack {
-      margin-top: 32px;
+      margin-top: 24px;
 
       h4 {
-        font-size: 12px;
-        font-weight: bold;
-        margin-bottom: 8px;
-        color: #878E95;
+        font-size: 1rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 16px;
+        color: var(--secondary);
+        padding: 8px 16px;
+        background-color: var(--on-background-border);
+        display: inline-block;
       }
-
 
       .tech-stack__stack__item {
         display: flex;
         align-items: center;
-        margin-top: 16px;
+        margin-top: 12px;
+        padding: 12px;
+        background-color: var(--background);
+        border: 2px solid var(--on-background-border);
+        transition: all 0.1s ease;
+
+        &:hover {
+          transform: translate(2px, 2px);
+          box-shadow: 2px 2px 0 var(--shadow-color);
+        }
 
         img {
-          width: 20px;
-          height: 20px;
-          margin-right: 8px;
+          width: 28px;
+          height: 28px;
+          margin-right: 12px;
         }
 
         p {
-          font-size: 12px;
+          font-size: 1rem;
+          font-weight: 600;
+          color: var(--on-surface);
+          margin: 0;
         }
       }
     }
@@ -45,26 +70,19 @@
 
 @media screen and (min-width: 600px) {
   .tech-stack {
-
     .tech-stack__title {
-      font-size: 20px;
+      font-size: 2rem;
     }
 
     .tech-stack__stack__list {
-
       .tech-stack__stack {
-
-        h3 {
-          font-size: 14px;
+        h4 {
+          font-size: 1.125rem;
         }
 
         .tech-stack__stack__item {
-          display: flex;
-          align-items: center;
-          margin-top: 16px;
-
           p {
-            font-size: 14px;
+            font-size: 1.125rem;
           }
         }
       }

--- a/src/components/Pures/TechStack/style.scss
+++ b/src/components/Pures/TechStack/style.scss
@@ -1,62 +1,71 @@
 .tech-stack {
-  margin-top: 48px;
-  /* Hapus background container dan border-bottom */
-  margin-bottom: 32px;
+  margin-top: 80px;
+  margin-bottom: 48px;
 
   .tech-stack__title {
+    display: inline-block;
     font-size: 1.5rem;
-    font-weight: 700;
+    font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--primary);
-    margin-bottom: 24px;
-    text-shadow: 2px 2px 0 var(--shadow-color);
-    word-break: break-word;
+    letter-spacing: 0.08em;
+    color: white;
+    margin-bottom: 32px;
+    padding: 10px 20px;
+    background-color: var(--primary);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .tech-stack__stack__list {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 20px;
+    gap: 24px;
 
     .tech-stack__stack {
-      margin-top: 20px;
-      /* Hapus background, border, shadow di container */
+      margin-top: 0;
 
       h4 {
-        font-size: 1rem;
+        font-size: 0.8125rem;
         font-weight: 700;
         text-transform: uppercase;
-        letter-spacing: 0.05em;
+        letter-spacing: 0.08em;
         margin-bottom: 12px;
-        color: var(--secondary);
-        padding: 8px 12px;
-        background-color: var(--surface);
+        color: var(--on-background);
+        padding: 6px 12px;
+        background-color: var(--warning);
         border: 2px solid var(--on-background-border);
+        border-radius: var(--border-radius);
         display: inline-block;
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        box-shadow: 3px 3px 0 var(--shadow-color);
       }
 
       .tech-stack__stack__item {
         display: flex;
         align-items: center;
-        margin-top: 12px;
-        padding: 12px;
-        background-color: var(--background);
+        margin-top: 10px;
+        padding: 14px 16px;
+        background-color: var(--surface);
         border: 2px solid var(--on-background-border);
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        border-radius: var(--border-radius);
+        box-shadow: 3px 3px 0 var(--shadow-color);
         transition: all 0.1s ease;
-        flex-wrap: nowrap;
 
         &:hover {
-          transform: translate(2px, 2px);
-          box-shadow: 1px 1px 0 var(--shadow-color);
+          transform: translate(3px, 3px);
+          box-shadow: none;
+          background-color: var(--primary);
+          color: white;
+
+          p {
+            color: white;
+          }
         }
 
         img {
           width: 28px;
           height: 28px;
-          margin-right: 12px;
+          margin-right: 14px;
           flex-shrink: 0;
         }
 
@@ -65,8 +74,7 @@
           font-weight: 600;
           color: var(--on-surface);
           margin: 0;
-          word-break: break-word;
-          overflow-wrap: break-word;
+          transition: color 0.1s ease;
         }
       }
     }
@@ -76,61 +84,43 @@
 @media screen and (min-width: 600px) {
   .tech-stack {
     .tech-stack__title {
-      font-size: 2rem;
-    }
-
-    .tech-stack__stack__list {
-      .tech-stack__stack {
-        h4 {
-          font-size: 1.125rem;
-        }
-
-        .tech-stack__stack__item {
-          p {
-            font-size: 1.125rem;
-          }
-        }
-      }
+      font-size: 1.75rem;
     }
   }
 }
 
 @media screen and (max-width: 599px) {
   .tech-stack {
-    margin-top: 32px;
-    margin-bottom: 24px;
+    margin-top: 48px;
+    margin-bottom: 32px;
 
     .tech-stack__title {
       font-size: 1.25rem;
-      margin-bottom: 16px;
+      margin-bottom: 20px;
     }
 
     .tech-stack__stack__list {
       grid-template-columns: 1fr;
-      gap: 12px;
+      gap: 16px;
 
       .tech-stack__stack {
-        margin-top: 16px;
-
         h4 {
-          font-size: 0.875rem;
-          padding: 6px 12px;
+          font-size: 0.75rem;
+          padding: 5px 10px;
           margin-bottom: 8px;
         }
 
         .tech-stack__stack__item {
-          padding: 10px;
-          flex-wrap: wrap;
-          gap: 8px;
+          padding: 12px;
 
           img {
             width: 24px;
             height: 24px;
-            margin-right: 0;
+            margin-right: 12px;
           }
 
           p {
-            font-size: 0.875rem;
+            font-size: 0.9375rem;
           }
         }
       }

--- a/src/components/Pures/TechStack/style.scss
+++ b/src/components/Pures/TechStack/style.scss
@@ -50,7 +50,7 @@
 
         &:hover {
           transform: translate(2px, 2px);
-          box-shadow: 1px 1px 0 var(--shadow-color));
+          box-shadow: 1px 1px 0 var(--shadow-color);
         }
 
         img {

--- a/src/components/Pures/TechStack/style.scss
+++ b/src/components/Pures/TechStack/style.scss
@@ -6,6 +6,7 @@
   border: 3px solid var(--on-background-border);
   box-shadow: 6px 6px 0 var(--shadow-color);
   padding: 32px;
+  overflow-x: hidden;
 
   .tech-stack__title {
     font-size: 1.5rem;
@@ -15,6 +16,7 @@
     color: var(--primary);
     margin-bottom: 24px;
     text-shadow: 2px 2px 0 var(--shadow-color);
+    word-break: break-word;
   }
 
   .tech-stack__stack__list {
@@ -45,6 +47,7 @@
         background-color: var(--background);
         border: 2px solid var(--on-background-border);
         transition: all 0.1s ease;
+        flex-wrap: nowrap;
 
         &:hover {
           transform: translate(2px, 2px);
@@ -55,6 +58,7 @@
           width: 28px;
           height: 28px;
           margin-right: 12px;
+          flex-shrink: 0;
         }
 
         p {
@@ -62,6 +66,8 @@
           font-weight: 600;
           color: var(--on-surface);
           margin: 0;
+          word-break: break-word;
+          overflow-wrap: break-word;
         }
       }
     }
@@ -83,6 +89,50 @@
         .tech-stack__stack__item {
           p {
             font-size: 1.125rem;
+          }
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .tech-stack {
+    margin-top: 32px;
+    padding-bottom: 32px;
+    padding: 20px 16px;
+
+    .tech-stack__title {
+      font-size: 1.25rem;
+      margin-bottom: 16px;
+    }
+
+    .tech-stack__stack__list {
+      grid-template-columns: 1fr;
+      gap: 16px;
+
+      .tech-stack__stack {
+        margin-top: 16px;
+
+        h4 {
+          font-size: 0.875rem;
+          padding: 6px 12px;
+          margin-bottom: 12px;
+        }
+
+        .tech-stack__stack__item {
+          padding: 10px;
+          flex-wrap: wrap;
+          gap: 8px;
+
+          img {
+            width: 24px;
+            height: 24px;
+            margin-right: 0;
+          }
+
+          p {
+            font-size: 0.875rem;
           }
         }
       }

--- a/src/components/Pures/TechStack/style.scss
+++ b/src/components/Pures/TechStack/style.scss
@@ -1,12 +1,7 @@
 .tech-stack {
   margin-top: 48px;
-  padding-bottom: 48px;
-  border-bottom: 3px solid var(--on-background-border);
-  background-color: var(--surface);
-  border: 3px solid var(--on-background-border);
-  box-shadow: 6px 6px 0 var(--shadow-color);
-  padding: 32px;
-  overflow-x: hidden;
+  /* Hapus background container dan border-bottom */
+  margin-bottom: 32px;
 
   .tech-stack__title {
     font-size: 1.5rem;
@@ -22,21 +17,24 @@
   .tech-stack__stack__list {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 24px;
+    gap: 20px;
 
     .tech-stack__stack {
-      margin-top: 24px;
+      margin-top: 20px;
+      /* Hapus background, border, shadow di container */
 
       h4 {
         font-size: 1rem;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.05em;
-        margin-bottom: 16px;
+        margin-bottom: 12px;
         color: var(--secondary);
-        padding: 8px 16px;
-        background-color: var(--on-background-border);
+        padding: 8px 12px;
+        background-color: var(--surface);
+        border: 2px solid var(--on-background-border);
         display: inline-block;
+        box-shadow: 2px 2px 0 var(--shadow-color);
       }
 
       .tech-stack__stack__item {
@@ -46,12 +44,13 @@
         padding: 12px;
         background-color: var(--background);
         border: 2px solid var(--on-background-border);
+        box-shadow: 2px 2px 0 var(--shadow-color);
         transition: all 0.1s ease;
         flex-wrap: nowrap;
 
         &:hover {
           transform: translate(2px, 2px);
-          box-shadow: 2px 2px 0 var(--shadow-color);
+          box-shadow: 1px 1px 0 var(--shadow-color));
         }
 
         img {
@@ -99,8 +98,7 @@
 @media screen and (max-width: 599px) {
   .tech-stack {
     margin-top: 32px;
-    padding-bottom: 32px;
-    padding: 20px 16px;
+    margin-bottom: 24px;
 
     .tech-stack__title {
       font-size: 1.25rem;
@@ -109,7 +107,7 @@
 
     .tech-stack__stack__list {
       grid-template-columns: 1fr;
-      gap: 16px;
+      gap: 12px;
 
       .tech-stack__stack {
         margin-top: 16px;
@@ -117,7 +115,7 @@
         h4 {
           font-size: 0.875rem;
           padding: 6px 12px;
-          margin-bottom: 12px;
+          margin-bottom: 8px;
         }
 
         .tech-stack__stack__item {

--- a/src/components/Pures/WorkHistories/style.scss
+++ b/src/components/Pures/WorkHistories/style.scss
@@ -6,6 +6,7 @@
   border: 3px solid var(--on-background-border);
   box-shadow: 6px 6px 0 var(--shadow-color);
   padding: 32px;
+  overflow-x: hidden;
 
   h3 {
     font-size: 1.5rem;
@@ -15,6 +16,7 @@
     color: var(--primary);
     margin-bottom: 24px;
     text-shadow: 2px 2px 0 var(--shadow-color);
+    word-break: break-word;
   }
 
   .work-histories__list {
@@ -46,10 +48,14 @@
         border-radius: 0;
         border: 3px solid var(--on-background-border);
         box-shadow: 3px 3px 0 var(--shadow-color);
+        flex-shrink: 0;
       }
 
       .work-histories__item__info {
         flex: 1;
+        min-width: 0;
+        word-break: break-word;
+        overflow-wrap: break-word;
 
         h4 {
           font-size: 1.125rem;
@@ -58,6 +64,8 @@
           text-transform: uppercase;
           letter-spacing: 0.05em;
           color: var(--on-surface);
+          word-break: break-word;
+          overflow-wrap: break-word;
         }
 
         .work-histories__item__info__company-name {
@@ -74,6 +82,8 @@
           padding: 8px 0;
           font-weight: 500;
           color: var(--on-background-grey);
+          word-break: break-word;
+          overflow-wrap: break-word;
         }
 
         .work-histories__item__info__date_range {
@@ -103,6 +113,67 @@
 
           .work-histories__item__info__company-name, .work-histories__item__info__date {
             font-size: 1.125rem;
+          }
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .work-histories {
+    margin-top: 32px;
+    padding-bottom: 32px;
+    padding: 20px 16px;
+
+    h3 {
+      font-size: 1.25rem;
+      margin-bottom: 16px;
+    }
+
+    .work-histories__list {
+      margin-top: 16px;
+
+      .work-histories__item {
+        flex-direction: column;
+        text-align: center;
+        padding: 16px;
+        margin-bottom: 12px;
+
+        img {
+          width: 60px;
+          height: 60px;
+          margin-right: 0;
+          margin-bottom: 12px;
+        }
+
+        .work-histories__item__info {
+          width: 100%;
+
+          h4 {
+            font-size: 1rem;
+            padding: 6px 0;
+          }
+
+          .work-histories__item__info__company-name {
+            font-size: 0.875rem;
+            padding: 4px 0;
+          }
+
+          .work-histories__item__info__date {
+            font-size: 0.75rem;
+            padding: 4px 0;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            align-items: center;
+          }
+
+          .work-histories__item__info__date_range {
+            margin-left: 0;
+            margin-top: 8px;
+            font-size: 0.75rem;
+            padding: 3px 8px;
           }
         }
       }

--- a/src/components/Pures/WorkHistories/style.scss
+++ b/src/components/Pures/WorkHistories/style.scss
@@ -1,12 +1,7 @@
 .work-histories {
   margin-top: 48px;
-  padding-bottom: 32px;
-  border-bottom: 3px solid var(--on-background-border);
-  background-color: var(--surface);
-  border: 3px solid var(--on-background-border);
-  box-shadow: 6px 6px 0 var(--shadow-color);
-  padding: 32px;
-  overflow-x: hidden;
+  /* Hapus border-bottom dan container background */
+  margin-bottom: 32px;
 
   h3 {
     font-size: 1.5rem;
@@ -21,20 +16,22 @@
 
   .work-histories__list {
     margin-top: 24px;
-
+    /* Hapus timeline, dots, dan dekorasi */
+    
     .work-histories__item {
       padding: 20px;
-      background-color: var(--background);
+      background-color: var(--surface);
       border: 3px solid var(--on-background-border);
       box-shadow: 4px 4px 0 var(--shadow-color);
       display: flex;
       align-items: center;
       margin-bottom: 16px;
       transition: all 0.1s ease;
+      /* Hapus offset timeline dan dots */
 
       &:hover {
         transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        box-shadow: 2px 2px 0 var(--shadow-color));
       }
 
       &:last-child {
@@ -46,9 +43,10 @@
         height: 80px;
         margin-right: 20px;
         border-radius: 0;
-        border: 3px solid var(--on-background-border);
+        border: 3px solid var(--primary);
         box-shadow: 3px 3px 0 var(--shadow-color);
         flex-shrink: 0;
+        /* Hapus rotasi */
       }
 
       .work-histories__item__info {
@@ -56,6 +54,7 @@
         min-width: 0;
         word-break: break-word;
         overflow-wrap: break-word;
+        /* Hapus background, border, shadow, rotasi */
 
         h4 {
           font-size: 1.125rem;
@@ -96,6 +95,7 @@
           background-color: var(--surface);
           border: 2px solid var(--on-background-border);
           display: inline-block;
+          box-shadow: 2px 2px 0 var(--shadow-color));
         }
       }
     }
@@ -123,7 +123,7 @@
 @media screen and (max-width: 599px) {
   .work-histories {
     margin-top: 32px;
-    padding-bottom: 32px;
+    margin-bottom: 32px;
     padding: 20px 16px;
 
     h3 {
@@ -139,12 +139,14 @@
         text-align: center;
         padding: 16px;
         margin-bottom: 12px;
+        /* Hapus offset */
 
         img {
           width: 60px;
           height: 60px;
           margin-right: 0;
           margin-bottom: 12px;
+          border-width: 3px;
         }
 
         .work-histories__item__info {
@@ -174,6 +176,7 @@
             margin-top: 8px;
             font-size: 0.75rem;
             padding: 3px 8px;
+            border-width: 2px;
           }
         }
       }

--- a/src/components/Pures/WorkHistories/style.scss
+++ b/src/components/Pures/WorkHistories/style.scss
@@ -1,41 +1,91 @@
 .work-histories {
   margin-top: 48px;
   padding-bottom: 32px;
-  border-bottom: 1px solid var(--on-background-border);
+  border-bottom: 3px solid var(--on-background-border);
+  background-color: var(--surface);
+  border: 3px solid var(--on-background-border);
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  padding: 32px;
 
   h3 {
-    font-size: 16px;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--primary);
+    margin-bottom: 24px;
+    text-shadow: 2px 2px 0 var(--shadow-color);
   }
 
   .work-histories__list {
-    margin-top: 16px;
+    margin-top: 24px;
 
     .work-histories__item {
-      padding: 16px 0;
+      padding: 20px;
+      background-color: var(--background);
+      border: 3px solid var(--on-background-border);
+      box-shadow: 4px 4px 0 var(--shadow-color);
       display: flex;
       align-items: center;
+      margin-bottom: 16px;
+      transition: all 0.1s ease;
+
+      &:hover {
+        transform: translate(2px, 2px);
+        box-shadow: 2px 2px 0 var(--shadow-color);
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
 
       img {
-        width: 56px;
-        height: 56px;
-        margin-right: 16px;
-        border-radius: 4px;
+        width: 80px;
+        height: 80px;
+        margin-right: 20px;
+        border-radius: 0;
+        border: 3px solid var(--on-background-border);
+        box-shadow: 3px 3px 0 var(--shadow-color);
       }
 
       .work-histories__item__info {
+        flex: 1;
+
         h4 {
-          font-size: 14px;
-          padding: 4px 0;
+          font-size: 1.125rem;
+          padding: 8px 0;
+          font-weight: 700;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--on-surface);
         }
 
-        .work-histories__item__info__company-name, .work-histories__item__info__date {
-          font-size: 12px;
-          padding: 4px 0;
+        .work-histories__item__info__company-name {
+          font-size: 1rem;
+          padding: 8px 0;
+          font-weight: 600;
+          color: var(--secondary);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
+
+        .work-histories__item__info__date {
+          font-size: 0.875rem;
+          padding: 8px 0;
+          font-weight: 500;
+          color: var(--on-background-grey);
         }
 
         .work-histories__item__info__date_range {
-          margin-left: 8px;
-          color: var(--on-background-grey)
+          margin-left: 12px;
+          color: var(--primary);
+          font-weight: 700;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          padding: 4px 12px;
+          background-color: var(--surface);
+          border: 2px solid var(--on-background-border);
+          display: inline-block;
         }
       }
     }
@@ -48,11 +98,11 @@
       .work-histories__item {
         .work-histories__item__info {
           h4 {
-            font-size: 16px;
+            font-size: 1.25rem;
           }
 
           .work-histories__item__info__company-name, .work-histories__item__info__date {
-            font-size: 14px;
+            font-size: 1.125rem;
           }
         }
       }

--- a/src/components/Pures/WorkHistories/style.scss
+++ b/src/components/Pures/WorkHistories/style.scss
@@ -1,100 +1,101 @@
 .work-histories {
-  margin-top: 48px;
-  /* Hapus border-bottom dan container background */
-  margin-bottom: 32px;
+  margin-top: 80px;
+  margin-bottom: 48px;
 
   h3 {
+    display: inline-block;
     font-size: 1.5rem;
-    font-weight: 700;
+    font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--primary);
-    margin-bottom: 24px;
-    text-shadow: 2px 2px 0 var(--shadow-color);
-    word-break: break-word;
+    letter-spacing: 0.08em;
+    color: white;
+    margin-bottom: 32px;
+    padding: 10px 20px;
+    background-color: var(--error);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .work-histories__list {
-    margin-top: 24px;
-    /* Hapus timeline, dots, dan dekorasi */
-    
+    margin-top: 0;
+    display: grid;
+    gap: 16px;
+
     .work-histories__item {
-      padding: 20px;
+      padding: 24px;
       background-color: var(--surface);
-      border: 3px solid var(--on-background-border);
+      border: 2px solid var(--on-background-border);
+      border-radius: var(--border-radius);
       box-shadow: 4px 4px 0 var(--shadow-color);
       display: flex;
       align-items: center;
-      margin-bottom: 16px;
       transition: all 0.1s ease;
-      /* Hapus offset timeline dan dots */
 
       &:hover {
-        transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color);
+        transform: translate(4px, 4px);
+        box-shadow: none;
       }
 
-      &:last-child {
-        margin-bottom: 0;
+      &:nth-child(even) {
+        border-left: 6px solid var(--primary);
+      }
+
+      &:nth-child(odd) {
+        border-left: 6px solid var(--secondary);
       }
 
       img {
-        width: 80px;
-        height: 80px;
-        margin-right: 20px;
-        border-radius: 0;
-        border: 3px solid var(--primary);
+        width: 72px;
+        height: 72px;
+        margin-right: 24px;
+        border-radius: var(--border-radius);
+        border: 2px solid var(--on-background-border);
         box-shadow: 3px 3px 0 var(--shadow-color);
         flex-shrink: 0;
-        /* Hapus rotasi */
       }
 
       .work-histories__item__info {
         flex: 1;
         min-width: 0;
-        word-break: break-word;
-        overflow-wrap: break-word;
-        /* Hapus background, border, shadow, rotasi */
 
         h4 {
           font-size: 1.125rem;
-          padding: 8px 0;
+          padding: 0 0 6px 0;
           font-weight: 700;
           text-transform: uppercase;
           letter-spacing: 0.05em;
           color: var(--on-surface);
-          word-break: break-word;
-          overflow-wrap: break-word;
         }
 
         .work-histories__item__info__company-name {
           font-size: 1rem;
-          padding: 8px 0;
-          font-weight: 600;
-          color: var(--secondary);
+          padding: 4px 0;
+          font-weight: 700;
+          color: var(--primary);
           text-transform: uppercase;
           letter-spacing: 0.05em;
         }
 
         .work-histories__item__info__date {
           font-size: 0.875rem;
-          padding: 8px 0;
+          padding: 4px 0;
           font-weight: 500;
           color: var(--on-background-grey);
-          word-break: break-word;
-          overflow-wrap: break-word;
         }
 
         .work-histories__item__info__date_range {
-          margin-left: 12px;
-          color: var(--primary);
+          margin-left: 10px;
+          color: var(--on-background);
           font-weight: 700;
           text-transform: uppercase;
           letter-spacing: 0.05em;
-          padding: 4px 12px;
-          background-color: var(--surface);
+          padding: 3px 10px;
+          background-color: var(--warning);
           border: 2px solid var(--on-background-border);
+          border-radius: var(--border-radius);
           display: inline-block;
+          font-size: 0.75rem;
           box-shadow: 2px 2px 0 var(--shadow-color);
         }
       }
@@ -102,8 +103,12 @@
   }
 }
 
-@media screen and (min-width: 600px){
+@media screen and (min-width: 600px) {
   .work-histories {
+    h3 {
+      font-size: 1.75rem;
+    }
+
     .work-histories__list {
       .work-histories__item {
         .work-histories__item__info {
@@ -111,8 +116,9 @@
             font-size: 1.25rem;
           }
 
-          .work-histories__item__info__company-name, .work-histories__item__info__date {
-            font-size: 1.125rem;
+          .work-histories__item__info__company-name,
+          .work-histories__item__info__date {
+            font-size: 1rem;
           }
         }
       }
@@ -122,31 +128,37 @@
 
 @media screen and (max-width: 599px) {
   .work-histories {
-    margin-top: 32px;
+    margin-top: 48px;
     margin-bottom: 32px;
-    padding: 20px 16px;
 
     h3 {
       font-size: 1.25rem;
-      margin-bottom: 16px;
+      margin-bottom: 20px;
     }
 
     .work-histories__list {
-      margin-top: 16px;
+      gap: 12px;
 
       .work-histories__item {
         flex-direction: column;
         text-align: center;
-        padding: 16px;
-        margin-bottom: 12px;
-        /* Hapus offset */
+        padding: 20px 16px;
+
+        &:nth-child(even),
+        &:nth-child(odd) {
+          border-left: 2px solid var(--on-background-border);
+          border-top: 6px solid var(--primary);
+        }
+
+        &:nth-child(odd) {
+          border-top-color: var(--secondary);
+        }
 
         img {
-          width: 60px;
-          height: 60px;
+          width: 56px;
+          height: 56px;
           margin-right: 0;
           margin-bottom: 12px;
-          border-width: 3px;
         }
 
         .work-histories__item__info {
@@ -154,29 +166,24 @@
 
           h4 {
             font-size: 1rem;
-            padding: 6px 0;
+            padding: 0 0 4px 0;
           }
 
           .work-histories__item__info__company-name {
             font-size: 0.875rem;
-            padding: 4px 0;
           }
 
           .work-histories__item__info__date {
             font-size: 0.75rem;
-            padding: 4px 0;
             display: flex;
             flex-direction: column;
-            gap: 4px;
+            gap: 6px;
             align-items: center;
           }
 
           .work-histories__item__info__date_range {
             margin-left: 0;
-            margin-top: 8px;
-            font-size: 0.75rem;
-            padding: 3px 8px;
-            border-width: 2px;
+            margin-top: 4px;
           }
         }
       }

--- a/src/components/Pures/WorkHistories/style.scss
+++ b/src/components/Pures/WorkHistories/style.scss
@@ -31,7 +31,7 @@
 
       &:hover {
         transform: translate(2px, 2px);
-        box-shadow: 2px 2px 0 var(--shadow-color));
+        box-shadow: 2px 2px 0 var(--shadow-color);
       }
 
       &:last-child {
@@ -95,7 +95,7 @@
           background-color: var(--surface);
           border: 2px solid var(--on-background-border);
           display: inline-block;
-          box-shadow: 2px 2px 0 var(--shadow-color));
+          box-shadow: 2px 2px 0 var(--shadow-color);
         }
       }
     }

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -11,7 +11,7 @@ import {
 } from 'react-icons/fa';
 
 export const navigation = {
-  title: 'Dimas Maulana Dwi Saputra',
+  title: '',
   menus: [
     {
       name: 'home',

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -46,6 +46,7 @@
     color: var(--on-background);
     background-color: var(--background);
     min-height: 100vh;
+    overflow-x: hidden;
 }
 
 * {
@@ -55,6 +56,7 @@
 }
 
 body {
+    overflow-x: hidden;
     overflow-y: scroll;
     font-family: 'Inter', sans-serif;
 }
@@ -64,6 +66,8 @@ h1, h2, h3, h4, h5, h6 {
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 h1 {
@@ -79,6 +83,32 @@ h2 {
 h3 {
     font-size: 1.5rem;
     margin-bottom: 0.75rem;
+}
+
+/* Mobile Responsive */
+@media screen and (max-width: 767px) {
+    h1 {
+        font-size: 1.75rem;
+        margin-bottom: 1rem;
+        line-height: 1.2;
+    }
+
+    h2 {
+        font-size: 1.5rem;
+        margin-bottom: 0.75rem;
+        line-height: 1.2;
+    }
+
+    h3 {
+        font-size: 1.25rem;
+        margin-bottom: 0.5rem;
+        line-height: 1.2;
+    }
+
+    :root {
+        --border-width: 2px;
+        --shadow-offset: 2px;
+    }
 }
 
 /* Neobrutalism Utility Classes */

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,13 +1,13 @@
 :root {
-    /* Neobrutalism Colors - High contrast, bold */
-    --primary: #FF6B6B;
-    --primary-variant: #E55555;
-    --secondary: #4ECDC4;
+    /* Neobrutalism Colors - Inspired by neobrutalism.dev */
+    --primary: #5294FF;
+    --primary-variant: #20294B;
+    --secondary: #05E17A;
     --background: #F7F5F2;
     --surface: #FFFFFF;
-    --error: #FF4757;
-    --warning: #FFA502;
-    --success: #2ED573;
+    --error: #FF871F;
+    --warning: #FF7A05;
+    --success: #1EFA94;
 
     /* Neobrutalism Typography */
     --on-background: #2D3436;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,31 +1,52 @@
 :root {
-    --primary: #BB86FC;
-    --primary-variant: #3700B3;
-    --secondary: #03DAC6;
-    --background: #121212;
-    --surface: #121212;
-    --error: #CF6679;
-    --warning: #F39C12;
-    --on-background: #FFFFFF;
-    --on-background-grey: #c7c7c7;
-    --on-background-border: #4b4b4b;
-    --on-surface: #FFFFFF;
-  }
-  
-  [data-theme="light"] {
-    --background: #FFFFFF;
-    --suface: #FFFFFF;
-    --on-background: #333333;
-    --on-background-grey: #6d6d6d;
-    --on-background-border: #e5e5e5;
-    --on-surface: #333333;
-  }
+    /* Neobrutalism Colors - High contrast, bold */
+    --primary: #FF6B6B;
+    --primary-variant: #E55555;
+    --secondary: #4ECDC4;
+    --background: #F7F5F2;
+    --surface: #FFFFFF;
+    --error: #FF4757;
+    --warning: #FFA502;
+    --success: #2ED573;
 
-  .app-container {
+    /* Neobrutalism Typography */
+    --on-background: #2D3436;
+    --on-background-grey: #636E72;
+    --on-background-border: #2D3436;
+    --on-surface: #2D3436;
+
+    /* Neobrutalism Borders & Shadows */
+    --border-width: 3px;
+    --border-style: solid;
+    --border-radius: 0px;
+    --shadow-offset: 4px;
+    --shadow-color: #2D3436;
+}
+
+[data-theme="light"] {
+    --background: #F7F5F2;
+    --surface: #FFFFFF;
+    --on-background: #2D3436;
+    --on-background-grey: #636E72;
+    --on-background-border: #2D3436;
+    --on-surface: #2D3436;
+}
+
+[data-theme="dark"] {
+    --background: #1E1E1E;
+    --surface: #2D2D2D;
+    --on-background: #F7F5F2;
+    --on-background-grey: #A0A0A0;
+    --on-background-border: #F7F5F2;
+    --on-surface: #F7F5F2;
+    --shadow-color: #F7F5F2;
+}
+
+.app-container {
     color: var(--on-background);
     background-color: var(--background);
     min-height: 100vh;
-  }
+}
 
 * {
     padding: 0;
@@ -38,22 +59,89 @@ body {
     font-family: 'Inter', sans-serif;
 }
 
-/* width */
-::-webkit-scrollbar {
-    width: 4px;
+/* Neobrutalism Base Styles */
+h1, h2, h3, h4, h5, h6 {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
-/* Track */
+h1 {
+    font-size: 2.5rem;
+    margin-bottom: 1.5rem;
+}
+
+h2 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+h3 {
+    font-size: 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+/* Neobrutalism Utility Classes */
+.neobrutalism-box {
+    border: var(--border-width) var(--border-style) var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 var(--shadow-color);
+    background-color: var(--surface);
+    color: var(--on-surface);
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.neobrutalism-button {
+    border: var(--border-width) var(--border-style) var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 var(--shadow-color);
+    background-color: var(--primary);
+    color: white;
+    padding: 0.75rem 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all 0.1s ease;
+}
+
+.neobrutalism-button:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0 var(--shadow-color);
+}
+
+.neobrutalism-button:active {
+    transform: translate(4px, 4px);
+    box-shadow: none;
+}
+
+.neobrutalism-badge {
+    display: inline-block;
+    border: 2px solid var(--on-background-border);
+    border-radius: 0;
+    background-color: var(--surface);
+    color: var(--on-surface);
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 6px;
+}
+
 ::-webkit-scrollbar-track {
     background: var(--background);
 }
 
-/* Handle */
 ::-webkit-scrollbar-thumb {
     background: var(--on-background-grey);
+    border: 2px solid var(--on-background-border);
 }
 
-/* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-    background: var(--on-background-grey);
+    background: var(--on-background-border);
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,50 +1,61 @@
 :root {
-    /* Neobrutalism Colors - Inspired by neobrutalism.dev */
-    --primary: #5294FF;
-    --primary-variant: #20294B;
-    --secondary: #05E17A;
-    --background: #F7F5F2;
+    /* Neobrutalism Colors - Bold & Vibrant */
+    --primary: #4A90FF;
+    --primary-variant: #1A2B5E;
+    --secondary: #00E676;
+    --background: #E8E4DE;
     --surface: #FFFFFF;
-    --error: #FF871F;
-    --warning: #FF7A05;
-    --success: #1EFA94;
+    --error: #FF6B35;
+    --warning: #FFBE0B;
+    --success: #00E676;
 
-    /* Neobrutalism Typography */
-    --on-background: #2D3436;
-    --on-background-grey: #636E72;
-    --on-background-border: #2D3436;
-    --on-surface: #2D3436;
+    /* Typography */
+    --on-background: #000000;
+    --on-background-grey: #555555;
+    --on-background-border: #000000;
+    --on-surface: #000000;
 
     /* Neobrutalism Borders & Shadows */
-    --border-width: 3px;
+    --border-width: 2px;
     --border-style: solid;
-    --border-radius: 0px;
+    --border-radius: 5px;
     --shadow-offset: 4px;
-    --shadow-color: #2D3436;
+    --shadow-color: #000000;
+
+    /* Grid Background */
+    --grid-color: rgba(0, 0, 0, 0.06);
+    --grid-size: 70px;
 }
 
 [data-theme="light"] {
-    --background: #F7F5F2;
+    --background: #E8E4DE;
     --surface: #FFFFFF;
-    --on-background: #2D3436;
-    --on-background-grey: #636E72;
-    --on-background-border: #2D3436;
-    --on-surface: #2D3436;
+    --on-background: #000000;
+    --on-background-grey: #555555;
+    --on-background-border: #000000;
+    --on-surface: #000000;
+    --shadow-color: #000000;
+    --grid-color: rgba(0, 0, 0, 0.06);
 }
 
 [data-theme="dark"] {
-    --background: #1E1E1E;
-    --surface: #2D2D2D;
-    --on-background: #F7F5F2;
-    --on-background-grey: #A0A0A0;
-    --on-background-border: #F7F5F2;
-    --on-surface: #F7F5F2;
-    --shadow-color: #F7F5F2;
+    --background: #1A1A2E;
+    --surface: #16213E;
+    --on-background: #EAEAEA;
+    --on-background-grey: #999999;
+    --on-background-border: #EAEAEA;
+    --on-surface: #EAEAEA;
+    --shadow-color: rgba(234, 234, 234, 0.4);
+    --grid-color: rgba(234, 234, 234, 0.04);
 }
 
 .app-container {
     color: var(--on-background);
     background-color: var(--background);
+    background-image:
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: var(--grid-size) var(--grid-size);
     min-height: 100vh;
     overflow-x: hidden;
 }
@@ -58,7 +69,8 @@
 body {
     overflow-x: hidden;
     overflow-y: scroll;
-    font-family: 'Inter', sans-serif;
+    font-family: 'DM Sans', sans-serif;
+    font-weight: 500;
 }
 
 /* Neobrutalism Base Styles */
@@ -71,13 +83,15 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-    font-size: 2.5rem;
+    font-size: 3rem;
     margin-bottom: 1.5rem;
+    line-height: 1.1;
 }
 
 h2 {
-    font-size: 2rem;
+    font-size: 2.25rem;
     margin-bottom: 1rem;
+    line-height: 1.15;
 }
 
 h3 {
@@ -88,9 +102,9 @@ h3 {
 /* Mobile Responsive */
 @media screen and (max-width: 767px) {
     h1 {
-        font-size: 1.75rem;
+        font-size: 2rem;
         margin-bottom: 1rem;
-        line-height: 1.2;
+        line-height: 1.15;
     }
 
     h2 {
@@ -106,8 +120,7 @@ h3 {
     }
 
     :root {
-        --border-width: 2px;
-        --shadow-offset: 2px;
+        --shadow-offset: 3px;
     }
 }
 
@@ -130,25 +143,21 @@ h3 {
     color: white;
     padding: 0.75rem 1.5rem;
     font-weight: 700;
+    font-family: 'DM Sans', sans-serif;
     text-transform: uppercase;
     cursor: pointer;
     transition: all 0.1s ease;
-}
 
-.neobrutalism-button:hover {
-    transform: translate(2px, 2px);
-    box-shadow: 2px 2px 0 var(--shadow-color);
-}
-
-.neobrutalism-button:active {
-    transform: translate(4px, 4px);
-    box-shadow: none;
+    &:hover {
+        transform: translate(var(--shadow-offset), var(--shadow-offset));
+        box-shadow: none;
+    }
 }
 
 .neobrutalism-badge {
     display: inline-block;
     border: 2px solid var(--on-background-border);
-    border-radius: 0;
+    border-radius: var(--border-radius);
     background-color: var(--surface);
     color: var(--on-surface);
     padding: 0.5rem 1rem;
@@ -158,20 +167,64 @@ h3 {
     letter-spacing: 0.05em;
 }
 
-/* Scrollbar */
+/* Section Title */
+.section-title {
+    display: inline-block;
+    font-size: 1.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--on-background);
+    margin-bottom: 32px;
+    padding: 12px 24px;
+    background-color: var(--primary);
+    color: white;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 var(--shadow-color);
+}
+
+/* Custom Neobrutalist Scrollbar */
 ::-webkit-scrollbar {
-    width: 6px;
+    width: 12px;
 }
 
 ::-webkit-scrollbar-track {
-    background: var(--background);
+    background: var(--surface);
+    border-left: 2px solid var(--on-background-border);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: var(--on-background-grey);
+    background: var(--on-background);
     border: 2px solid var(--on-background-border);
+    border-radius: 0;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: var(--on-background-border);
+    background: var(--primary);
+}
+
+/* Marquee Animation */
+@keyframes marquee {
+    0% {
+        transform: translateX(0);
+    }
+    100% {
+        transform: translateX(calc(-100% - 24px));
+    }
+}
+
+@keyframes marquee-reverse {
+    0% {
+        transform: translateX(calc(-100% - 24px));
+    }
+    100% {
+        transform: translateX(0);
+    }
+}
+
+/* Selection */
+::selection {
+    background: var(--primary);
+    color: white;
 }


### PR DESCRIPTION
- Update global.scss with neobrutalism color scheme (bold colors, high contrast)
- Apply neobrutalism styling to all components:
  - Navigation: Bold borders, solid shadows, hover effects
  - App container: Thick borders, box shadows
  - Homepage: Retro layout with solid borders
  - PersonalInformation: Bold title, card-style description
  - Tags: Badge-style with solid borders
  - Tag: Individual badge styling with hover effects
  - SocialMedias: Square social buttons with hover effects
  - TechStack: Grid layout with category badges
  - WorkHistories: Card-style work experience items
  - Badges: Grid layout for certifications
  - Footer: Bold footer with design credit
  - AnnouncementBar: Spotify green bar with solid borders
- Add neobrutalism utility classes (boxes, buttons, badges)
- Implement responsive design for all components
- Maintain dark mode support with neobrutalism colors

This redesign transforms the website from clean/minimal to bold/retro neobrutalism style inspired by neobrutalism.dev design system.