### PR TITLE
feat: add Tech Talks section with video playlist

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -6,6 +6,7 @@ import NotebooksPage from '../Pages/NotebooksPage';
 import Navigation from '../Pures/Navigation';
 import { navigation } from '../../content';
 import NotebookPage from '../Pages/NotebookPage';
+import TalksPage from '../Pages/TalksPage';
 
 import './style.scss';
 import ThemeContext from '../../contexts/ThemeContext';
@@ -39,6 +40,7 @@ function App() {
               <Route path="/about" element={<AboutPage />} />
               <Route path="/notebooks" element={<NotebooksPage />} />
               <Route path="/notebooks/:slug" element={<NotebookPage />} />
+              <Route path="/talks" element={<TalksPage />} />
             </Routes>
 
           </div>

--- a/src/components/Pages/HomePage/index.jsx
+++ b/src/components/Pages/HomePage/index.jsx
@@ -5,6 +5,7 @@ import TechStack from '../../Pures/TechStack';
 import WorkHistories from '../../Pures/WorkHistories';
 import Badges from '../../Pures/Badges';
 import Marquee from '../../Pures/Marquee';
+import FeaturedTalks from '../../Pures/FeaturedTalks';
 import { tags } from '../../../content';
 
 function HomePage() {
@@ -35,6 +36,7 @@ function HomePage() {
       </div>
 
       <TechStack />
+      <FeaturedTalks />
       <WorkHistories />
       <Badges />
     </main>

--- a/src/components/Pages/TalksPage/index.jsx
+++ b/src/components/Pages/TalksPage/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './style.scss';
+import Talks from '../../Pures/Talks';
+
+function TalksPage() {
+  return (
+    <main className="talks-page">
+      <h2 className="talks-page__title">Talks</h2>
+      <p className="talks-page__subtitle">Sharing session tentang teknologi yang pernah saya deliver.</p>
+      <Talks />
+    </main>
+  );
+}
+
+export default TalksPage;

--- a/src/components/Pages/TalksPage/style.scss
+++ b/src/components/Pages/TalksPage/style.scss
@@ -1,0 +1,23 @@
+.talks-page {
+  min-height: 75vh;
+
+  .talks-page__title {
+    display: inline-block;
+    font-size: 1.75rem;
+    font-weight: 800;
+    margin-bottom: 12px;
+    padding: 10px 20px;
+    background-color: var(--primary);
+    color: white;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
+  }
+
+  .talks-page__subtitle {
+    font-weight: 500;
+    font-size: 1.0625rem;
+    color: var(--on-background-grey);
+    margin-top: 8px;
+  }
+}

--- a/src/components/Pures/FeaturedTalks/index.jsx
+++ b/src/components/Pures/FeaturedTalks/index.jsx
@@ -35,8 +35,8 @@ function FeaturedTalks() {
             />
             <div className="featured-talks__overlay">
               <span className="featured-talks__play-icon">&#9654;</span>
+              <span className="featured-talks__main-title">{main.title}</span>
             </div>
-            <span className="featured-talks__main-title">{main.title}</span>
           </a>
         )}
         <div className="featured-talks__side">

--- a/src/components/Pures/FeaturedTalks/index.jsx
+++ b/src/components/Pures/FeaturedTalks/index.jsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import './style.scss';
+import { techTalks } from '../../../content';
+
+function FeaturedTalks() {
+  const featured = useMemo(() => {
+    const shuffled = [...techTalks].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, 3);
+  }, []);
+
+  const [main, ...side] = featured;
+
+  return (
+    <section className="featured-talks">
+      <div className="featured-talks__header">
+        <h3 className="featured-talks__title">Tech Talks</h3>
+        <span className="featured-talks__badge">LIVE</span>
+      </div>
+      <p className="featured-talks__subtitle">
+        Sharing session tentang teknologi yang pernah saya deliver.
+      </p>
+      <div className="featured-talks__grid">
+        {main && (
+          <a
+            className="featured-talks__main"
+            href={`https://www.youtube.com/watch?v=${main.videoId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              src={`https://img.youtube.com/vi/${main.videoId}/hqdefault.jpg`}
+              alt={main.title}
+              loading="lazy"
+            />
+            <div className="featured-talks__overlay">
+              <span className="featured-talks__play-icon">&#9654;</span>
+            </div>
+            <span className="featured-talks__main-title">{main.title}</span>
+          </a>
+        )}
+        <div className="featured-talks__side">
+          {side.map((talk) => (
+            <a
+              key={talk.videoId}
+              className="featured-talks__side-item"
+              href={`https://www.youtube.com/watch?v=${talk.videoId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={`https://img.youtube.com/vi/${talk.videoId}/mqdefault.jpg`}
+                alt={talk.title}
+                loading="lazy"
+              />
+              <span className="featured-talks__side-title">{talk.title}</span>
+            </a>
+          ))}
+        </div>
+      </div>
+      <Link to="/talks" className="featured-talks__cta">
+        Lihat semua video
+        <span className="featured-talks__cta-arrow">&rarr;</span>
+      </Link>
+    </section>
+  );
+}
+
+export default FeaturedTalks;

--- a/src/components/Pures/FeaturedTalks/index.jsx
+++ b/src/components/Pures/FeaturedTalks/index.jsx
@@ -29,11 +29,20 @@ function FeaturedTalks() {
             rel="noopener noreferrer"
           >
             <img
+              className="featured-talks__main-bg"
               src={`https://img.youtube.com/vi/${main.videoId}/hqdefault.jpg`}
-              alt={main.title}
+              alt=""
               loading="lazy"
             />
-            <div className="featured-talks__overlay">
+            <div className="featured-talks__main-thumb-wrapper">
+              <img
+                className="featured-talks__main-thumb"
+                src={`https://img.youtube.com/vi/${main.videoId}/hqdefault.jpg`}
+                alt={main.title}
+                loading="lazy"
+              />
+            </div>
+            <div className="featured-talks__main-overlay">
               <span className="featured-talks__play-icon">&#9654;</span>
               <span className="featured-talks__main-title">{main.title}</span>
             </div>

--- a/src/components/Pures/FeaturedTalks/style.scss
+++ b/src/components/Pures/FeaturedTalks/style.scss
@@ -1,0 +1,215 @@
+.featured-talks {
+  margin-top: 48px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--on-background);
+  }
+
+  &__badge {
+    display: inline-block;
+    padding: 4px 10px;
+    font-size: 0.6875rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    color: white;
+    background-color: #FF3D00;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 2px 2px 0 var(--shadow-color);
+    animation: pulse-badge 2s ease-in-out infinite;
+  }
+
+  &__subtitle {
+    font-weight: 500;
+    font-size: 1rem;
+    color: var(--on-background-grey);
+    margin-top: 8px;
+  }
+
+  &__grid {
+    margin-top: 20px;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  &__main {
+    position: relative;
+    display: block;
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
+    overflow: hidden;
+    transition: all 0.1s ease;
+    text-decoration: none;
+
+    &:hover {
+      transform: translate(4px, 4px);
+      box-shadow: none;
+      border-color: var(--primary);
+
+      .featured-talks__overlay {
+        opacity: 1;
+      }
+    }
+
+    img {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      object-fit: cover;
+      display: block;
+    }
+  }
+
+  &__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  &__play-icon {
+    font-size: 2rem;
+    color: white;
+  }
+
+  &__main-title {
+    display: block;
+    padding: 12px 16px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--on-background);
+    line-height: 1.4;
+  }
+
+  &__side {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  &__side-item {
+    display: block;
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 3px 3px 0 var(--shadow-color);
+    overflow: hidden;
+    transition: all 0.1s ease;
+    text-decoration: none;
+
+    &:hover {
+      transform: translate(3px, 3px);
+      box-shadow: none;
+      border-color: var(--primary);
+    }
+
+    img {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      object-fit: cover;
+      display: block;
+    }
+  }
+
+  &__side-title {
+    display: block;
+    padding: 10px 12px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--on-background);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
+    padding: 12px 24px;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: white;
+    background-color: var(--primary);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
+    text-decoration: none;
+    transition: all 0.1s ease;
+
+    &:hover {
+      transform: translate(4px, 4px);
+      box-shadow: none;
+      background-color: var(--secondary);
+      color: #000000;
+    }
+  }
+
+  &__cta-arrow {
+    font-size: 1.25rem;
+    transition: transform 0.15s ease;
+  }
+
+  &:hover &__cta-arrow {
+    transform: translateX(4px);
+  }
+}
+
+@keyframes pulse-badge {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+@media screen and (min-width: 600px) {
+  .featured-talks {
+    &__grid {
+      grid-template-columns: 1.4fr 1fr;
+    }
+
+    &__side {
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr 1fr;
+    }
+
+    &__main-title {
+      font-size: 1rem;
+    }
+
+    &__side-title {
+      font-size: 0.875rem;
+    }
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .featured-talks {
+    &__main-title {
+      font-size: 0.8125rem;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+}

--- a/src/components/Pures/FeaturedTalks/style.scss
+++ b/src/components/Pures/FeaturedTalks/style.scss
@@ -78,9 +78,14 @@
   &__main-thumb-wrapper {
     position: relative;
     z-index: 1;
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
     padding: 20px 16px;
     display: flex;
+    align-items: center;
     justify-content: center;
+    box-sizing: border-box;
   }
 
   &__main-thumb {

--- a/src/components/Pures/FeaturedTalks/style.scss
+++ b/src/components/Pures/FeaturedTalks/style.scss
@@ -59,23 +59,44 @@
       box-shadow: none;
       border-color: var(--primary);
 
-      .featured-talks__overlay {
+      .featured-talks__main-overlay {
         opacity: 1;
       }
     }
-
-    img {
-      width: 100%;
-      aspect-ratio: 16 / 9;
-      object-fit: cover;
-      display: block;
-    }
   }
 
-  &__overlay {
+  &__main-bg {
+    position: absolute;
+    inset: -4px;
+    width: calc(100% + 8px);
+    height: calc(100% + 8px);
+    object-fit: cover;
+    filter: blur(12px) brightness(0.35);
+    z-index: 0;
+  }
+
+  &__main-thumb-wrapper {
+    position: relative;
+    z-index: 1;
+    padding: 20px 16px;
+    display: flex;
+    justify-content: center;
+  }
+
+  &__main-thumb {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    display: block;
+    border-radius: 3px;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+  }
+
+  &__main-overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.1) 50%, transparent 100%);
+    z-index: 2;
+    background: rgba(0, 0, 0, 0.3);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -97,8 +118,8 @@
     bottom: 0;
     left: 0;
     right: 0;
-    padding: 12px 16px;
-    font-size: 1rem;
+    padding: 16px;
+    font-size: 0.9375rem;
     font-weight: 600;
     color: white;
     line-height: 1.4;
@@ -199,6 +220,10 @@
     &__side {
       grid-template-columns: 1fr;
       grid-template-rows: 1fr 1fr;
+    }
+
+    &__main-thumb-wrapper {
+      padding: 24px 20px;
     }
 
     &__main-title {

--- a/src/components/Pures/FeaturedTalks/style.scss
+++ b/src/components/Pures/FeaturedTalks/style.scss
@@ -243,12 +243,22 @@
 
 @media screen and (max-width: 599px) {
   .featured-talks {
+    &__side-title {
+      display: none;
+    }
+
     &__main-title {
       font-size: 0.8125rem;
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       overflow: hidden;
+    }
+
+    &__side-item {
+      img {
+        border-radius: 3px;
+      }
     }
   }
 }

--- a/src/components/Pures/FeaturedTalks/style.scss
+++ b/src/components/Pures/FeaturedTalks/style.scss
@@ -75,26 +75,35 @@
   &__overlay {
     position: absolute;
     inset: 0;
-    background: rgba(0, 0, 0, 0.25);
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.1) 50%, transparent 100%);
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     opacity: 0;
     transition: opacity 0.15s ease;
+    padding: 16px;
   }
 
   &__play-icon {
-    font-size: 2rem;
+    font-size: 2.5rem;
     color: white;
+    margin-bottom: 12px;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
   }
 
   &__main-title {
-    display: block;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
     padding: 12px 16px;
-    font-size: 0.9375rem;
+    font-size: 1rem;
     font-weight: 600;
-    color: var(--on-background);
+    color: white;
     line-height: 1.4;
+    text-align: center;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.8), transparent);
   }
 
   &__side {
@@ -193,7 +202,7 @@
     }
 
     &__main-title {
-      font-size: 1rem;
+      font-size: 1.0625rem;
     }
 
     &__side-title {

--- a/src/components/Pures/Talks/index.jsx
+++ b/src/components/Pures/Talks/index.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './style.scss';
+import { techTalks } from '../../../content';
+
+function TalkCard({ talk }) {
+  const { title, videoId } = talk;
+  const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+  const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
+
+  return (
+    <a
+      className="talk-card"
+      href={videoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <div className="talk-card__thumbnail">
+        <img src={thumbnailUrl} alt={title} loading="lazy" />
+        <div className="talk-card__play">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </div>
+      </div>
+      <h4 className="talk-card__title">{title}</h4>
+    </a>
+  );
+}
+
+function Talks() {
+  return (
+    <div className="talks">
+      {
+        techTalks.map((talk) => (
+          <TalkCard key={talk.videoId} talk={talk} />
+        ))
+      }
+    </div>
+  );
+}
+
+TalkCard.propTypes = {
+  talk: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    videoId: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default Talks;

--- a/src/components/Pures/Talks/style.scss
+++ b/src/components/Pures/Talks/style.scss
@@ -1,0 +1,91 @@
+.talks {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+
+  .talk-card {
+    display: block;
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 3px 3px 0 var(--shadow-color);
+    transition: all 0.1s ease;
+    text-decoration: none;
+    overflow: hidden;
+
+    &:hover {
+      transform: translate(3px, 3px);
+      box-shadow: none;
+      border-color: var(--primary);
+
+      .talk-card__play {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+      }
+    }
+
+    &__thumbnail {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      overflow: hidden;
+      border-bottom: 2px solid var(--on-background-border);
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
+
+    &__play {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0.8);
+      width: 48px;
+      height: 48px;
+      background-color: var(--primary);
+      border: 2px solid var(--on-background-border);
+      border-radius: var(--border-radius);
+      box-shadow: 2px 2px 0 var(--shadow-color);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      transition: all 0.15s ease;
+
+      svg {
+        width: 24px;
+        height: 24px;
+        color: white;
+        margin-left: 2px;
+      }
+    }
+
+    &__title {
+      padding: 12px 16px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--on-background);
+      line-height: 1.4;
+    }
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .talks {
+    grid-template-columns: repeat(2, 1fr);
+
+    .talk-card__title {
+      font-size: 0.9375rem;
+    }
+  }
+}
+
+@media screen and (min-width: 900px) {
+  .talks {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -22,6 +22,10 @@ export const navigation = {
       url: '/notebooks',
     },
     {
+      name: 'talks',
+      url: '/talks',
+    },
+    {
       name: 'about',
       url: '/about',
     },

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -276,6 +276,121 @@ export const workHistories = [
 
 export const credentials = {};
 
+export const techTalks = [
+  {
+    title: 'AWS X Dicoding LIVE : Storage dan Database di AWS',
+    videoId: 'eaSoKJJ67yE',
+  },
+  {
+    title: 'Web Developer From Zero to Hero',
+    videoId: 'LTIaYXvz__4',
+  },
+  {
+    title: 'AWS X Dicoding LIVE: Automation on AWS',
+    videoId: 'NC8TswA7PiM',
+  },
+  {
+    title: 'Dicoding Developer Coaching #56: Back-End | Pengenalan Bahasa Pemrograman JavaScript',
+    videoId: 'axFB3XOE_y8',
+  },
+  {
+    title: 'Dicoding Dev Coaching #60: Back-End | Mengenal Operator, Control Flow, dan Perulangan di JavaScript',
+    videoId: 'FaWGkWB59vA',
+  },
+  {
+    title: 'Dicoding Developer Coaching #62 : Back-End | Object, Array, Map, dan Sets di JavaScript',
+    videoId: 'YjSPw9aZFZg',
+  },
+  {
+    title: 'Dicoding Developer Coaching #70 : Back-End | Package Manager di JavaScript',
+    videoId: '_GYr7G7NCKE',
+  },
+  {
+    title: 'Dicoding Developer Coaching #76 : Back-End | JavaScript Concurrency',
+    videoId: 'QyXqZqJhInc',
+  },
+  {
+    title: 'Dicoding Developer Coaching #78 : Back-End | Menulis Unit Testing di JavaScript',
+    videoId: 'UdQpwR1ub7E',
+  },
+  {
+    title: 'AWS x Dicoding LIVE : "Agile vs DevOps"',
+    videoId: 'mo391NjVx4U',
+  },
+  {
+    title: 'Developer Coaching #83 : Back-End | Ketahui Node.js API yang Penting untuk Pengembangan Back-End',
+    videoId: 'sDXZqe2rGuM',
+  },
+  {
+    title: 'Dicoding Developer Coaching #86 : Back-End | Membuat HTTP Server dengan Node.js',
+    videoId: 'GaWlgj6QrP8',
+  },
+  {
+    title: 'Dicoding Developer Coaching #91: Back-End | Membuat HTTP Server di berbagai Framework Node.js',
+    videoId: 'Y2EV1vRBE3A',
+  },
+  {
+    title: 'Dicoding Developer Coaching #92 : Back-End | Deploy Aplikasi Node.js di AWS',
+    videoId: '9QzA1rULMQo',
+  },
+  {
+    title: 'AWS x Dicoding LIVE : "Serverless Microservices, Container, dan Orchestration"',
+    videoId: 'PbZyl4IE35M',
+  },
+  {
+    title: 'Dicoding Developer Coaching #99 : Back-End | Automation Testing dengan Postman',
+    videoId: '7ao-9pWDRUs',
+  },
+  {
+    title: 'Dicoding Developer Coaching #100 | Special Episode',
+    videoId: '5HAu7hJ3oYY',
+  },
+  {
+    title: 'Dicoding Developer Coaching #101: Back-End | Hapi Plugin dan Data Validation',
+    videoId: 'zwN3NRPlrsI',
+  },
+  {
+    title: '#DevCoach 175: React | Kenalan dengan React: UI Web Masa Kini!',
+    videoId: '-0kstDNdhA8',
+  },
+  {
+    title: '#DevCoach 178: React | Teknik React Menghidupkan UI dengan State',
+    videoId: 'ltOervtEmHc',
+  },
+  {
+    title: '#DevCoach 193: React | Hooks Mengubah Segalanya!',
+    videoId: 'gtQ_QqC7vfQ',
+  },
+  {
+    title: '#DevCoach 189: React | Kenalan dengan Lifecycle Component',
+    videoId: 'icsirDtMu1o',
+  },
+  {
+    title: 'DevCoach 210: React | JANGAN LANGSUNG RTK! Pahami Dulu Redux Fundamental Di Sini.',
+    videoId: 'Wb5WxpFguVg',
+  },
+  {
+    title: 'DevCoach 212: New Course | Belajar Pemrograman Rust untuk Pemula',
+    videoId: 'KOK0qGasby0',
+  },
+  {
+    title: 'Baparekraf Developer Day 2021',
+    videoId: 'VXFvAthCSqQ',
+  },
+  {
+    title: 'Baparekraf Developer Day 2022',
+    videoId: 'W5soN70ajb0',
+  },
+  {
+    title: 'Baparekraf Developer Day 2023',
+    videoId: 'aLCc9XG-Uqk',
+  },
+  {
+    title: 'Back End Track - BDD 2024',
+    videoId: 'zlfGihNfRSo',
+  },
+];
+
 export const notebooks = [
   {
     slug: 'mengenal-clawdbot-asisten-ai-pribadi',


### PR DESCRIPTION
## What's Changed

Adds a new **Tech Talks** section to showcase 28 video tech talk sessions from YouTube playlist.

### Changes

**New Section: `/talks`**
- Grid layout of 28 video cards (1 col mobile, 2 col tablet, 3 col desktop)
- Each card: YouTube thumbnail + video title
- Click opens video on YouTube in new tab
- Play button overlay on hover
- Neobrutalism style: thick borders, hard shadows, press-in hover

**Homepage: Featured Talks**
- Spotlight layout: 1 main video (large) + 2 side videos (small)
- Title overlay on main video thumbnail (gradient from bottom)
- LIVE badge with pulse animation
- CTA button linking to `/talks` page
- Videos randomized on each page load

**Navigation**
- Added "Talks" menu item between Notebooks and About

### Commits (8)

1. `feat: add techTalks data with 28 video entries from YouTube playlist`
2. `feat: add Talks menu item to navigation`
3. `feat: add Talks card grid component with neobrutalism style`
4. `feat: add TalksPage component with title and subtitle`
5. `feat: add /talks route to app router`
6. `feat: add FeaturedTalks component with spotlight layout for homepage`
7. `feat: add FeaturedTalks section to homepage between TechStack and WorkHistories`
8. `fix: overlay main video title on thumbnail to remove whitespace`

### Files Changed (9 files, +595 lines)

| File | Change |
|------|--------|
| `src/content/index.js` | Added `techTalks` data array + nav menu item |
| `src/components/App/index.jsx` | Added `/talks` route |
| `src/components/Pages/HomePage/index.jsx` | Added FeaturedTalks component |
| `src/components/Pages/TalksPage/` | New page component + styles |
| `src/components/Pures/Talks/` | New card grid component + styles |
| `src/components/Pures/FeaturedTalks/` | New spotlight component + styles |