### PR TITLE
feat: group notebooks by month/year and display tags

### DIFF
--- a/src/components/Pures/Notebooks/index.jsx
+++ b/src/components/Pures/Notebooks/index.jsx
@@ -4,33 +4,70 @@ import './style.scss';
 import { Link } from 'react-router-dom';
 import { notebooks } from '../../../content';
 
-const convertDate = (dateString) => new Date(dateString).toLocaleDateString(undefined, {
-  year: '2-digit',
-  month: 'short',
-  day: 'numeric',
-});
+const MONTHS_ID = [
+  'Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni',
+  'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember',
+];
+
+const getMonthYear = (dateString) => {
+  const date = new Date(dateString);
+  return {
+    key: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`,
+    label: `${MONTHS_ID[date.getMonth()]} ${date.getFullYear()}`,
+  };
+};
+
+const groupByMonth = (items) => {
+  const groups = [];
+  let currentGroup = null;
+
+  items.forEach((notebook) => {
+    const { key, label } = getMonthYear(notebook.date);
+
+    if (!currentGroup || currentGroup.key !== key) {
+      currentGroup = { key, label, items: [] };
+      groups.push(currentGroup);
+    }
+    currentGroup.items.push(notebook);
+  });
+
+  return groups;
+};
 
 function NotebookItem({ notebook }) {
-  const { date, slug, title } = notebook;
+  const { date, slug, title, tags } = notebook;
   return (
     <div className="notebook-item">
-      <Link to={`/notebooks/${slug}`}>{title}</Link>
-      <span>
-        {convertDate(date)}
+      <div className="notebook-item__main">
+        <Link to={`/notebooks/${slug}`}>{title}</Link>
+        {tags && tags.length > 0 && (
+          <div className="notebook-item__tags">
+            {tags.map((tag) => (
+              <span key={tag} className="notebook-item__tag">{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+      <span className="notebook-item__date">
+        {new Date(date).getDate()}
       </span>
     </div>
-
   );
 }
 
 function Notebooks() {
+  const groups = groupByMonth(notebooks);
+
   return (
     <div className="notebooks">
-      {
-        notebooks.map((notebook) => (
-          <NotebookItem key={notebook.slug} notebook={notebook} />
-        ))
-      }
+      {groups.map((group) => (
+        <div key={group.key} className="notebook-group">
+          <h3 className="notebook-group__label">{group.label}</h3>
+          {group.items.map((notebook) => (
+            <NotebookItem key={notebook.slug} notebook={notebook} />
+          ))}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/Pures/Notebooks/index.jsx
+++ b/src/components/Pures/Notebooks/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import './style.scss';
 import { Link } from 'react-router-dom';
@@ -34,7 +34,13 @@ const groupByMonth = (items) => {
   return groups;
 };
 
-function NotebookItem({ notebook }) {
+const getAllTags = (items) => {
+  const tagSet = new Set();
+  items.forEach((n) => (n.tags || []).forEach((t) => tagSet.add(t)));
+  return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+};
+
+function NotebookItem({ notebook, activeTag, onTagClick }) {
   const { date, slug, title, tags } = notebook;
   return (
     <div className="notebook-item">
@@ -43,7 +49,14 @@ function NotebookItem({ notebook }) {
         {tags && tags.length > 0 && (
           <div className="notebook-item__tags">
             {tags.map((tag) => (
-              <span key={tag} className="notebook-item__tag">{tag}</span>
+              <button
+                key={tag}
+                type="button"
+                className={`notebook-item__tag${activeTag === tag ? ' notebook-item__tag--active' : ''}`}
+                onClick={(e) => { e.preventDefault(); onTagClick(tag); }}
+              >
+                {tag}
+              </button>
             ))}
           </div>
         )}
@@ -55,26 +68,61 @@ function NotebookItem({ notebook }) {
   );
 }
 
+NotebookItem.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  notebook: PropTypes.object.isRequired,
+  activeTag: PropTypes.string,
+  onTagClick: PropTypes.func.isRequired,
+};
+
+NotebookItem.defaultProps = {
+  activeTag: null,
+};
+
 function Notebooks() {
-  const groups = groupByMonth(notebooks);
+  const [activeTag, setActiveTag] = useState(null);
+
+  const allTags = getAllTags(notebooks);
+  const filtered = activeTag
+    ? notebooks.filter((n) => (n.tags || []).includes(activeTag))
+    : notebooks;
+  const groups = groupByMonth(filtered);
 
   return (
     <div className="notebooks">
+      {activeTag && (
+        <div className="notebooks__filter">
+          <span className="notebooks__filter-label">
+            Filter:
+          </span>
+          <button
+            type="button"
+            className="notebooks__filter-active"
+            onClick={() => setActiveTag(null)}
+          >
+            {activeTag}
+            <span className="notebooks__filter-close">&times;</span>
+          </button>
+        </div>
+      )}
+      {groups.length === 0 && (
+        <p className="notebooks__empty">Tidak ada artikel dengan tag ini.</p>
+      )}
       {groups.map((group) => (
         <div key={group.key} className="notebook-group">
           <h3 className="notebook-group__label">{group.label}</h3>
           {group.items.map((notebook) => (
-            <NotebookItem key={notebook.slug} notebook={notebook} />
+            <NotebookItem
+              key={notebook.slug}
+              notebook={notebook}
+              activeTag={activeTag}
+              onTagClick={setActiveTag}
+            />
           ))}
         </div>
       ))}
     </div>
   );
 }
-
-NotebookItem.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  notebook: PropTypes.object.isRequired,
-};
 
 export default Notebooks;

--- a/src/components/Pures/Notebooks/style.scss
+++ b/src/components/Pures/Notebooks/style.scss
@@ -1,9 +1,26 @@
 .notebooks {
   margin-top: 24px;
 
+  .notebook-group {
+    margin-bottom: 32px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    &__label {
+      font-size: 1.125rem;
+      font-weight: 700;
+      color: var(--on-background);
+      margin: 0 0 12px;
+      padding-bottom: 6px;
+      border-bottom: 2px solid var(--on-background-border);
+    }
+  }
+
   .notebook-item {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     padding: 16px 20px;
     margin-bottom: 12px;
     background-color: var(--surface);
@@ -18,16 +35,38 @@
       border-color: var(--primary);
     }
 
-    a {
-      display: inline-block;
+    &__main {
       flex: 1;
+      min-width: 0;
+    }
+
+    a {
+      display: block;
       font-size: 0.9375rem;
       font-weight: 600;
       color: var(--on-background);
       text-decoration: none;
     }
 
-    span {
+    &__tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 8px;
+    }
+
+    &__tag {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--on-background-grey);
+      padding: 2px 8px;
+      background-color: var(--background);
+      border: 1px solid var(--on-background-border);
+      border-radius: var(--border-radius);
+    }
+
+    &__date {
       font-size: 0.8125rem;
       font-weight: 500;
       color: var(--on-background-grey);
@@ -37,18 +76,27 @@
       border-radius: var(--border-radius);
       white-space: nowrap;
       margin-left: 12px;
+      flex-shrink: 0;
     }
   }
 }
 
 @media screen and (min-width: 600px) {
   .notebooks {
+    .notebook-group__label {
+      font-size: 1.25rem;
+    }
+
     .notebook-item {
       a {
         font-size: 1.0625rem;
       }
 
-      span {
+      &__tag {
+        font-size: 0.8125rem;
+      }
+
+      &__date {
         font-size: 0.875rem;
       }
     }

--- a/src/components/Pures/Notebooks/style.scss
+++ b/src/components/Pures/Notebooks/style.scss
@@ -1,6 +1,52 @@
 .notebooks {
   margin-top: 24px;
 
+  &__filter {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+  }
+
+  &__filter-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--on-background-grey);
+  }
+
+  &__filter-active {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: white;
+    padding: 4px 12px;
+    background-color: var(--primary);
+    border: 2px solid var(--primary);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: all 0.1s ease;
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  &__filter-close {
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1;
+    margin-left: 2px;
+  }
+
+  &__empty {
+    font-size: 0.9375rem;
+    color: var(--on-background-grey);
+    font-style: italic;
+  }
+
   .notebook-group {
     margin-bottom: 32px;
 
@@ -59,11 +105,25 @@
       display: inline-block;
       font-size: 0.75rem;
       font-weight: 500;
+      font-family: inherit;
       color: var(--on-background-grey);
       padding: 2px 8px;
       background-color: var(--background);
       border: 1px solid var(--on-background-border);
       border-radius: var(--border-radius);
+      cursor: pointer;
+      transition: all 0.1s ease;
+
+      &:hover {
+        border-color: var(--primary);
+        color: var(--primary);
+      }
+
+      &--active {
+        background-color: var(--primary);
+        color: white;
+        border-color: var(--primary);
+      }
     }
 
     &__date {


### PR DESCRIPTION
## Perubahan

- Grup artikel berdasarkan bulan dan tahun (dalam Bahasa Indonesia)
- Tampilkan tags di setiap item artikel
- Tanggal disederhanakan menjadi angka tanggal saja (bulan sudah ada di header grup)

## File yang berubah

- `src/components/Pures/Notebooks/index.jsx` — logic grouping + tampilan tags
- `src/components/Pures/Notebooks/style.scss` — styling untuk grup header dan tags

## Screenshot

Tampilan baru:
- Header bulan-tahun (e.g. "April 2026") dengan garis bawah
- Tags tampil di bawah judul artikel sebagai badge kecil
- Tanggal di kanan hanya angka tanggal