### PR TITLE
feat: JSON-LD Structured Data

### DIFF
--- a/src/components/Pures/SEO/index.jsx
+++ b/src/components/Pures/SEO/index.jsx
@@ -3,8 +3,58 @@ import { Helmet } from 'react-helmet-async';
 import PropTypes from 'prop-types';
 
 const SITE_NAME = 'Dimas Maulana Dwi Saputra';
+const SITE_URL = 'https://dmds.dev';
 const DEFAULT_IMAGE = 'https://dmds.dev/assets/images/profile.jpg';
 const DEFAULT_LOCALE = 'id_ID';
+
+function buildJsonLd({ title, description, url, type, publishedTime, tags }) {
+  if (type === 'article') {
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: title,
+      description: description,
+      datePublished: publishedTime || undefined,
+      author: {
+        '@type': 'Person',
+        name: SITE_NAME,
+        url: SITE_URL,
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: SITE_NAME,
+        logo: {
+          '@type': 'ImageObject',
+          url: `${SITE_URL}/assets/images/profile.jpg`,
+        },
+      },
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': url,
+      },
+    };
+
+    if (tags && tags.length > 0) {
+      schema.keywords = tags.join(', ');
+    }
+
+    return schema;
+  }
+
+  // Default: WebSite schema
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE_NAME,
+    url: url || SITE_URL,
+    description: description,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${SITE_URL}/?q={search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    },
+  };
+}
 
 function SEO({
   title,
@@ -49,6 +99,8 @@ function SEO({
     }
   }
 
+  const jsonLd = buildJsonLd({ title, description, url, type, publishedTime, tags });
+
   return (
     <Helmet>
       <title>{documentTitle}</title>
@@ -56,6 +108,7 @@ function SEO({
       {metaTags.map((tag, index) => (
         <meta key={`${tag.name || tag.property}-${index}`} {...tag} />
       ))}
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
     </Helmet>
   );
 }


### PR DESCRIPTION
## Summary

Add JSON-LD structured data to the SEO component for improved search engine rich snippets.

## Changes

- Added a `buildJsonLd()` helper function that generates schema.org JSON-LD based on page type
- For `type='website'` (homepage, listing pages): emits a **WebSite** schema with name, url, description, and a SearchAction potential action
- For `type='article'` (notebook/blog pages): emits a **BlogPosting** schema with headline, description, datePublished, author (Person), publisher (Organization with logo), mainEntityOfPage, and keywords from tags
- JSON-LD is injected as a `<script type="application/ld+json">` tag inside the existing Helmet component
- Uses `JSON.stringify()` to serialize the schema object

## Benefits

- Google and other search engines can display rich snippets (article cards with publish date, author info, etc.)
- Improves SEO discoverability and click-through rates from search results
- Validates against Google's Rich Results Test and Schema.org specifications

## File Modified

- `src/components/Pures/SEO/index.jsx`