### PR TITLE
feat: add RSS feed for blog articles

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/default.min.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown-light.min.css" rel="stylesheet">
+    <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/rss.xml" />
     <title>Dimas Maulana Dwi Saputra</title>
   </head>
   <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,6 @@ User-agent: *
 Disallow:
 
 Sitemap: https://dmds.dev/sitemap.xml
+
+# RSS Feed
+# https://dmds.dev/rss.xml

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Dimas Maulana Dwi Saputra</title>
+    <link>https://dmds.dev</link>
+    <description>Secuil catatan yang perlu disimpan dan dibagikan</description>
+    <language>id</language>
+    <lastBuildDate>Sat, 18 Apr 2026 04:48:56 GMT</lastBuildDate>
+    <item>
+      <title>Tiga Belas Tahun di Makkah: Pelajaran dari Seerah yang Mengubah Cara Saya Melihat Perjalanan Spiritual</title>
+      <link>https://dmds.dev/notebooks/tiga-belas-tahun-di-makkah</link>
+      <guid>https://dmds.dev/notebooks/tiga-belas-tahun-di-makkah</guid>
+      <pubDate>Fri, 17 Apr 2026 00:00:00 GMT</pubDate>
+      <description><![CDATA[Tiga Belas Tahun di Makkah: Pelajaran dari Seerah yang Mengubah Cara Saya Melihat Perjalanan Spiritual Saya punya kebiasaan buruk: kalau sudah putus untuk berubah, saya mau langsung sempurna. Besok shalat tahajud. Besok puasa Sunnah Senin-Kamis. Besok baca Al-Quran satu juz sehari. Besok mulai belaj...]]></description>
+      <category>Islami</category>
+      <category>Seerah</category>
+      <category>Spiritual</category>
+    </item>
+    <item>
+      <title>Lima Detik yang Lebih Berharga dari Lima Jam</title>
+      <link>https://dmds.dev/notebooks/lima-detik-yang-lebih-berharga-dari-lima-jam</link>
+      <guid>https://dmds.dev/notebooks/lima-detik-yang-lebih-berharga-dari-lima-jam</guid>
+      <pubDate>Thu, 16 Apr 2026 00:00:00 GMT</pubDate>
+      <description><![CDATA[Lima Detik yang Lebih Berharga dari Lima Jam Sore itu, habis meeting panjang membahas roadmap quarter berikutnya, saya pulang dengan kepala masih penuh todo list. Begitu pintu depan dibuka, anak yang kedua — yang belum genap dua tahun — langsung berlari ke arah saya, mengangkat sebelah tangannya yan...]]></description>
+      <category>Parenting</category>
+      <category>Fatherhood</category>
+      <category>Engineering Manager</category>
+    </item>
+    <item>
+      <title>Mengenal ClawDBot: Asisten AI Pribadi</title>
+      <link>https://dmds.dev/notebooks/mengenal-clawdbot-asisten-ai-pribadi</link>
+      <guid>https://dmds.dev/notebooks/mengenal-clawdbot-asisten-ai-pribadi</guid>
+      <pubDate>Sun, 08 Mar 2026 00:00:00 GMT</pubDate>
+      <description><![CDATA[Halo! Baru-baru ini gue setup asisten AI pribadi yang gue kasih nama Zay yang berjalan di framework OpenClaw. Sebenarnya ini coba-coba doang, tapi setelah dipakai beberapa hari, ternyata lumayan asik juga! Gue coba share pengalaman gue ya. --Side note: Tulisan ini sebenarnya dibuat oleh Zai sendiri ...]]></description>
+      <category>AI</category>
+      <category>OpenClaw</category>
+      <category>Zai</category>
+    </item>
+    <item>
+      <title>Seru-seruan bareng AI pakai Node.js</title>
+      <link>https://dmds.dev/notebooks/seru-seruan-bareng-ai-pakai-node-js</link>
+      <guid>https://dmds.dev/notebooks/seru-seruan-bareng-ai-pakai-node-js</guid>
+      <pubDate>Wed, 28 Feb 2024 00:00:00 GMT</pubDate>
+      <description><![CDATA[Kecerdasan buatan alias Artificial Intelligence (AI) itu bikin gue mindblow 🤯. Meskipun gue ngerti dunia Software Developer, tapi setiap kali nyoba produk yang dikasih sentuhan AI, gue cuma bisa manggut-manggut sambil bilang, 'wah, ini kayak sihir beneran'. Tentu aja, gue paham, nggak ada sihir-sih...]]></description>
+      <category>AI</category>
+      <category>Developer</category>
+      <category>Node.js</category>
+    </item>
+    <item>
+      <title>Bulan, Unordinary Woman - Bab 1: Dahaga</title>
+      <link>https://dmds.dev/notebooks/bulan-unordinary-woman-bab-1</link>
+      <guid>https://dmds.dev/notebooks/bulan-unordinary-woman-bab-1</guid>
+      <pubDate>Thu, 24 Feb 2022 00:00:00 GMT</pubDate>
+      <description><![CDATA[Siksa Dahaga | Penyakit langka yang hanya menimpa mereka yang tak menghiraukan kelezatan kantin saat jam pelajaran. Bab 1: Dahaga Desember 2012, bulan di mana seluruh pelajar SMA di negeri ini merasa kehilangan semangat di kelas-kelas mereka. Angan-angan mereka telah menjelajah jauh, berlibur di tem...]]></description>
+      <category>story</category>
+      <category>bulan</category>
+    </item>
+    <item>
+      <title>Bulan, Unordinary Woman - Pengantar</title>
+      <link>https://dmds.dev/notebooks/bulan-unordinary-woman-pengantar</link>
+      <guid>https://dmds.dev/notebooks/bulan-unordinary-woman-pengantar</guid>
+      <pubDate>Wed, 23 Feb 2022 00:00:00 GMT</pubDate>
+      <description><![CDATA[Bulan, Wanita Tak Biasa | Ketika Sang Pencipta menciptakan wanita dengan keterbatasan. Prolog Dalam pandangan mataku yang malu-malu, dia muncul seperti bidadari yang melangkah dengan lekuk kaki yang merayakan kegembiraan hidupnya. Saat itu, aku masih duduk di bangku SMK, menyaksikan wanita yang tera...]]></description>
+      <category>story</category>
+      <category>bulan</category>
+    </item>
+  </channel>
+</rss>

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+const BASE_URL = 'https://dmds.dev';
+
+// Parse notebooks from src/content/index.js without importing React icons
+function getNotebooks() {
+  const contentPath = path.join(ROOT_DIR, 'src/content/index.js');
+  const content = fs.readFileSync(contentPath, 'utf-8');
+
+  // Extract the notebooks array using regex
+  const match = content.match(/export const notebooks = (\[[\s\S]*?\n\]);/);
+  if (!match) {
+    console.warn('Could not parse notebooks from content file');
+    return [];
+  }
+
+  // Use eval to parse the array (it's a simple data array with no function calls)
+  const arrayStr = match[1];
+  // eslint-disable-next-line no-eval
+  const notebooks = eval(`(${arrayStr})`);
+  return notebooks;
+}
+
+// Strip markdown syntax from text
+function stripMarkdown(md) {
+  return md
+    .replace(/!\[.*?\]\(.*?\)/g, '')       // images
+    .replace(/\[([^\]]*)\]\(.*?\)/g, '$1') // links - keep text
+    .replace(/#{1,6}\s+/g, '')             // headings
+    .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, '$2') // bold/italic
+    .replace(/`{1,3}[^`]*`{1,3}/g, '')     // inline code
+    .replace(/>\s+/g, '')                   // blockquotes
+    .replace(/[-*+]\s+/g, '')               // unordered list markers
+    .replace(/\d+\.\s+/g, '')               // ordered list markers
+    .replace(/---+/g, '')                   // horizontal rules
+    .replace(/\n{2,}/g, ' ')                // multiple newlines
+    .replace(/\n/g, ' ')                    // single newlines
+    .trim();
+}
+
+// Convert date string to RFC 822 format
+function toRFC822(dateStr) {
+  const date = new Date(dateStr);
+  return date.toUTCString();
+}
+
+// Escape XML special characters
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function generateRSS() {
+  const notebooks = getNotebooks();
+
+  const items = notebooks.map((notebook) => {
+    // Read the markdown content file
+    const contentPath = path.join(ROOT_DIR, 'public', notebook.content);
+    let description = '';
+    if (fs.existsSync(contentPath)) {
+      const mdContent = fs.readFileSync(contentPath, 'utf-8');
+      const stripped = stripMarkdown(mdContent);
+      description = stripped.substring(0, 300);
+      if (stripped.length > 300) {
+        description += '...';
+      }
+    }
+
+    const link = `${BASE_URL}/notebooks/${notebook.slug}`;
+    const pubDate = toRFC822(notebook.date);
+
+    const categoryTags = (notebook.tags || [])
+      .map((tag) => `      <category>${escapeXml(tag)}</category>`)
+      .join('\n');
+
+    return `    <item>
+      <title>${escapeXml(notebook.title)}</title>
+      <link>${link}</link>
+      <guid>${link}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description><![CDATA[${description}]]></description>
+${categoryTags}
+    </item>`;
+  });
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Dimas Maulana Dwi Saputra</title>
+    <link>${BASE_URL}</link>
+    <description>Secuil catatan yang perlu disimpan dan dibagikan</description>
+    <language>id</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+${items.join('\n')}
+  </channel>
+</rss>`;
+
+  const outputPath = path.join(ROOT_DIR, 'public', 'rss.xml');
+  fs.writeFileSync(outputPath, rss, 'utf-8');
+  console.log(`RSS feed generated at public/rss.xml with ${notebooks.length} items`);
+}
+
+generateRSS();


### PR DESCRIPTION
## Summary

This PR adds RSS feed generation for the dmds.dev blog.

### Changes

- **New script** `scripts/generate-rss.mjs`: Parses notebooks from `src/content/index.js`, reads each markdown file to extract a 300-character description (with markdown syntax stripped), and generates a valid RSS 2.0 XML feed at `public/rss.xml`.
  - Channel info: title, link, description, language (id)
  - Each RSS item includes: title, link, guid, pubDate (RFC 822), description (CDATA-wrapped), and category tags
- **index.html**: Added `<link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/rss.xml" />` in the `<head>` section for auto-discovery
- **robots.txt**: Added comment with RSS feed URL reference

### Generated Feed

The feed includes all 6 notebook articles with proper RSS 2.0 formatting.