### PR TITLE
feat: add reading time estimate to notebook articles

### DIFF
--- a/src/components/Pages/NotebookPage/index.jsx
+++ b/src/components/Pages/NotebookPage/index.jsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import { notebooks } from '../../../content';
 import AudioPlayer from '../../Pures/AudioPlayer';
 import SEO from '../../Pures/SEO';
+import { readingTime } from '../../../utils/readingTime';
 import './style.scss';
 
 function NotebookPage() {
@@ -85,6 +86,7 @@ function NotebookPage() {
   }
 
   const { title, tags } = notebook;
+  const estimatedReadingTime = readingTime(content);
 
   return (
     <main className={`notebook-detail${hasAudio ? ' notebook-detail--with-player' : ''}`}>
@@ -104,6 +106,13 @@ function NotebookPage() {
               {tag}
             </span>
           ))}
+        </div>
+        <div className="notebook-detail__reading-time">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+          </svg>
+          <span>{estimatedReadingTime}</span>
         </div>
       </header>
 

--- a/src/components/Pages/NotebookPage/style.scss
+++ b/src/components/Pages/NotebookPage/style.scss
@@ -66,6 +66,21 @@
         content: '#';
       }
     }
+
+    .notebook-detail__reading-time {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 12px;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--on-background-grey);
+      letter-spacing: 0.02em;
+
+      svg {
+        opacity: 0.6;
+      }
+    }
   }
 
   .markdown-body {

--- a/src/utils/readingTime.js
+++ b/src/utils/readingTime.js
@@ -1,0 +1,34 @@
+/**
+ * Calculate estimated reading time for markdown text.
+ * Uses 200 words per minute as average reading speed for Indonesian text.
+ *
+ * @param {string} text - Markdown content
+ * @returns {string} Reading time estimate, e.g. "3 menit baca"
+ */
+export function readingTime(text) {
+  if (!text || typeof text !== 'string') return '1 menit baca';
+
+  // Strip markdown syntax
+  const plainText = text
+    .replace(/!\[.*?\]\(.*?\)/g, '')        // images
+    .replace(/\[.*?\]\(.*?\)/g, '')          // links (keep link text? no, remove for cleaner count)
+    .replace(/^#{1,6}\s+.*/gm, '')           // headings
+    .replace(/```[\s\S]*?```/g, '')           // code blocks
+    .replace(/`[^`]+`/g, '')                 // inline code
+    .replace(/\*\*.*?\*\*/g, '')             // bold
+    .replace(/_.*?_/g, '')                   // italic
+    .replace(/~~.*?~~/g, '')                 // strikethrough
+    .replace(/>\s+.*/gm, '')                 // blockquotes
+    .replace(/[-*+]\s+/gm, '')               // unordered list markers
+    .replace(/\d+\.\s+/gm, '')               // ordered list markers
+    .replace(/---+/g, '')                    // horizontal rules
+    .replace(/\|/g, '')                      // table pipes
+    .replace(/[*_`~#>|]/g, '')               // remaining markdown chars
+    .replace(/\n+/g, ' ')                    // newlines to spaces
+    .trim();
+
+  const wordCount = plainText.split(/\s+/).filter(Boolean).length;
+  const minutes = Math.ceil(wordCount / 200);
+
+  return `${Math.max(1, minutes)} menit baca`;
+}


### PR DESCRIPTION
## Summary

Adds an estimated reading time indicator to notebook/blog article pages.

### Changes

- **New utility:** `src/utils/readingTime.js` — calculates reading time from markdown content using 200 WPM (Indonesian text average). Strips markdown syntax before counting. Returns a string like `"3 menit baca"` (minimum 1 minute).

- **NotebookPage component:** After content loads, computes reading time and displays it in the article header below the tags, with a clock SVG icon.

- **Styles:** `.notebook-detail__reading-time` styled consistently with existing tag styling — small text, subtle grey color, inline-flex layout.

### Files changed
- `src/utils/readingTime.js` (new)
- `src/components/Pages/NotebookPage/index.jsx`
- `src/components/Pages/NotebookPage/style.scss`