### PR TITLE
feat: add related articles section to notebook pages

### DIFF
--- a/src/components/Pages/NotebookPage/index.jsx
+++ b/src/components/Pages/NotebookPage/index.jsx
@@ -6,6 +6,8 @@ import ReactMarkdown from 'react-markdown';
 import { notebooks } from '../../../content';
 import AudioPlayer from '../../Pures/AudioPlayer';
 import SEO from '../../Pures/SEO';
+import RelatedArticles from '../../Pures/RelatedArticles';
+import { getRelatedArticles } from '../../../utils/relatedArticles';
 import './style.scss';
 
 function NotebookPage() {
@@ -85,6 +87,7 @@ function NotebookPage() {
   }
 
   const { title, tags } = notebook;
+  const relatedArticles = getRelatedArticles(notebook, notebooks);
 
   return (
     <main className={`notebook-detail${hasAudio ? ' notebook-detail--with-player' : ''}`}>
@@ -112,6 +115,10 @@ function NotebookPage() {
           {content}
         </ReactMarkdown>
       </div>
+
+      {relatedArticles.length > 0 && (
+        <RelatedArticles articles={relatedArticles} />
+      )}
 
       {hasAudio && <AudioPlayer audioSrc={audioSrc} />}
       {audioChecked && !hasAudio && (

--- a/src/components/Pures/RelatedArticles/index.jsx
+++ b/src/components/Pures/RelatedArticles/index.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './style.scss';
+
+const MONTHS_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  return `${date.getDate()} ${MONTHS_SHORT[date.getMonth()]} ${date.getFullYear()}`;
+};
+
+function RelatedArticles({ articles }) {
+  if (!articles || articles.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="related-articles">
+      <h3 className="related-articles__heading">Artikel Terkait</h3>
+      <nav className="related-articles__list">
+        {articles.map((article) => (
+          <article key={article.slug} className="related-articles__card">
+            <Link to={`/notebooks/${article.slug}`} className="related-articles__link">
+              <span className="related-articles__title">{article.title}</span>
+            </Link>
+            <span className="related-articles__date">{formatDate(article.date)}</span>
+            {article.tags && article.tags.length > 0 && (
+              <div className="related-articles__tags">
+                {article.tags.map((tag) => (
+                  <span key={tag} className="related-articles__tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </article>
+        ))}
+      </nav>
+    </section>
+  );
+}
+
+export default RelatedArticles;

--- a/src/components/Pures/RelatedArticles/style.scss
+++ b/src/components/Pures/RelatedArticles/style.scss
@@ -1,0 +1,100 @@
+.related-articles {
+  margin-top: 48px;
+
+  &__heading {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--on-background);
+    margin: 0 0 20px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid var(--on-background-border);
+  }
+
+  &__list {
+    display: grid;
+    gap: 12px;
+  }
+
+  &__card {
+    padding: 16px 20px;
+    background-color: var(--surface);
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 3px 3px 0 var(--shadow-color);
+    transition: all 0.1s ease;
+
+    &:hover {
+      transform: translate(3px, 3px);
+      box-shadow: none;
+      border-color: var(--primary);
+    }
+  }
+
+  &__link {
+    text-decoration: none;
+    display: block;
+
+    &:hover .related-articles__title {
+      color: var(--primary);
+    }
+  }
+
+  &__title {
+    display: block;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--on-background);
+    line-height: 1.4;
+    transition: color 0.1s ease;
+  }
+
+  &__date {
+    display: block;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--on-background-grey);
+    margin-top: 6px;
+  }
+
+  &__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+  }
+
+  &__tag {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: var(--border-radius);
+    border: 2px solid var(--on-background-border);
+    font-weight: 700;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background-color: var(--background);
+    box-shadow: 2px 2px 0 var(--shadow-color);
+    color: var(--on-background-grey);
+
+    &::before {
+      content: '#';
+    }
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .related-articles {
+    &__list {
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 16px;
+    }
+
+    &__title {
+      font-size: 1.0625rem;
+    }
+
+    &__tag {
+      font-size: 0.8125rem;
+    }
+  }
+}

--- a/src/utils/relatedArticles.js
+++ b/src/utils/relatedArticles.js
@@ -1,0 +1,49 @@
+/**
+ * Get related articles based on shared tags and recency.
+ *
+ * @param {Object} currentNotebook - The current notebook article
+ * @param {string} currentNotebook.slug - Slug of the current article
+ * @param {string[]} currentNotebook.tags - Tags of the current article
+ * @param {string} currentNotebook.date - Date string (YYYY-MM-DD)
+ * @param {Array} allNotebooks - Array of all notebook articles
+ * @param {number} maxResults - Maximum number of related articles to return
+ * @returns {Array} Array of related articles with slug, title, tags, date, score
+ */
+export function getRelatedArticles(currentNotebook, allNotebooks, maxResults = 3) {
+  const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+  const now = new Date();
+  const sixMonthsAgo = new Date(now.getTime() - SIX_MONTHS_MS);
+
+  const scored = allNotebooks
+    .filter((nb) => nb.slug !== currentNotebook.slug)
+    .map((nb) => {
+      let score = 0;
+
+      // +3 points for each shared tag
+      const currentTags = currentNotebook.tags || [];
+      const nbTags = nb.tags || [];
+      const sharedTags = currentTags.filter((tag) => nbTags.includes(tag));
+      score += sharedTags.length * 3;
+
+      // +1 point if the article is recent (within last 6 months)
+      const nbDate = new Date(nb.date);
+      if (nbDate >= sixMonthsAgo) {
+        score += 1;
+      }
+
+      return {
+        slug: nb.slug,
+        title: nb.title,
+        tags: nb.tags,
+        date: nb.date,
+        score,
+      };
+    })
+    .filter((nb) => nb.score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return new Date(b.date) - new Date(a.date);
+    });
+
+  return scored.slice(0, maxResults);
+}


### PR DESCRIPTION
## Summary

Adds a related articles feature to notebook detail pages, showing readers articles with shared tags.

## Changes

- **New utility** (`src/utils/relatedArticles.js`): Scoring algorithm that awards +3 points per shared tag and +1 point for articles published within the last 6 months. Returns top 3 results sorted by score (descending), then by date.

- **New component** (`src/components/Pures/RelatedArticles/`): Renders an "Artikel Terkait" section with article cards containing title, formatted date, and tag badges. Uses neobrutalist design matching the existing site style (2px borders, offset shadows, hover translate effect). Responsive layout: stacked on mobile, grid on desktop.

- **Modified** (`src/components/Pages/NotebookPage/index.jsx`): Integrates the RelatedArticles component between the markdown body and the audio player. Only renders when related articles are found.

## Files Changed

| File | Action |
|------|--------|
| `src/utils/relatedArticles.js` | Created |
| `src/components/Pures/RelatedArticles/index.jsx` | Created |
| `src/components/Pures/RelatedArticles/style.scss` | Created |
| `src/components/Pages/NotebookPage/index.jsx` | Modified |

## Testing

- `npm run build` succeeds with no errors