### PR TITLE
feat: add proper 404 page with neobrutalist design

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -7,6 +7,7 @@ import Navigation from '../Pures/Navigation';
 import { navigation } from '../../content';
 import NotebookPage from '../Pages/NotebookPage';
 import TalksPage from '../Pages/TalksPage';
+import NotFoundPage from '../Pages/NotFoundPage';
 
 import './style.scss';
 import ThemeContext from '../../contexts/ThemeContext';
@@ -41,6 +42,7 @@ function App() {
               <Route path="/notebooks" element={<NotebooksPage />} />
               <Route path="/notebooks/:slug" element={<NotebookPage />} />
               <Route path="/talks" element={<TalksPage />} />
+              <Route path="*" element={<NotFoundPage />} />
             </Routes>
 
           </div>

--- a/src/components/Pages/NotFoundPage/index.jsx
+++ b/src/components/Pages/NotFoundPage/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './style.scss';
+
+function NotFoundPage() {
+  return (
+    <main className="not-found">
+      <div className="not-found__card">
+        <h1 className="not-found__code">404</h1>
+        <h2 className="not-found__subtitle">Halaman yang kamu cari tidak ditemukan</h2>
+        <p className="not-found__description">
+          Mungkin halaman ini sudah dipindahkan, dihapus, atau memang tidak pernah ada.
+          Atau mungkin kamu tersesat di internet?
+        </p>
+        <Link to="/" className="not-found__back-link">
+          ← Kembali ke Beranda
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+export default NotFoundPage;

--- a/src/components/Pages/NotFoundPage/style.scss
+++ b/src/components/Pages/NotFoundPage/style.scss
@@ -1,0 +1,109 @@
+.not-found {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 75vh;
+  text-align: center;
+
+  .not-found__card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    padding: 48px 64px;
+    background-color: var(--surface);
+    border: var(--border-width) var(--border-style) var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 var(--shadow-color);
+    max-width: 600px;
+    width: 100%;
+  }
+
+  .not-found__code {
+    font-size: 8rem;
+    font-weight: 800;
+    line-height: 1;
+    color: var(--on-background);
+    background-color: var(--primary);
+    padding: 12px 40px;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: 4px 4px 0 var(--shadow-color);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .not-found__subtitle {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--on-background);
+    text-transform: none;
+    letter-spacing: 0;
+    line-height: 1.3;
+  }
+
+  .not-found__description {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--on-background-grey);
+    line-height: 1.6;
+    max-width: 420px;
+  }
+
+  .not-found__back-link {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 12px 28px;
+    background-color: var(--primary);
+    color: white;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    border: 2px solid var(--on-background-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 var(--shadow-color);
+    cursor: pointer;
+    transition: all 0.1s ease;
+
+    &:hover {
+      transform: translate(var(--shadow-offset), var(--shadow-offset));
+      box-shadow: none;
+    }
+
+    &:visited {
+      color: white;
+    }
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .not-found {
+    min-height: 60vh;
+
+    .not-found__card {
+      padding: 32px 24px;
+      gap: 20px;
+    }
+
+    .not-found__code {
+      font-size: 5rem;
+      padding: 10px 28px;
+    }
+
+    .not-found__subtitle {
+      font-size: 1.25rem;
+    }
+
+    .not-found__description {
+      font-size: 0.9rem;
+    }
+
+    .not-found__back-link {
+      padding: 10px 22px;
+      font-size: 0.875rem;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a proper, personality-filled 404 page in Bahasa Indonesia with neobrutalist design.

## Changes
- **New component:** `src/components/Pages/NotFoundPage/index.jsx`
  - Large "404" heading with neobrutalist card styling
  - Subtitle: "Halaman yang kamu cari tidak ditemukan"
  - Fun description about being lost on the internet
  - "Kembali ke Beranda" CTA link using react-router-dom `Link`
- **New styles:** `src/components/Pages/NotFoundPage/style.scss`
  - Centered layout, 8rem 404 heading
  - Neobrutalist design: 2px border, offset shadow, rounded corners
  - CTA button with hover translate+shadow effect
  - Responsive design for mobile
- **Updated:** `src/components/App/index.jsx`
  - Added catch-all `path="*"` route as the last route
  - Renders `NotFoundPage` for any unmatched URLs

## Design Details
- Uses site's existing CSS variables (`--primary`, `--surface`, `--shadow-color`, etc.)
- Consistent with existing neobrutalist design language
- Fully responsive with mobile breakpoints at 767px

## Testing
- Build passes successfully (`npm run build`)