### PR TITLE
feat: add table of contents for long articles

### DIFF
--- a/src/components/Pages/NotebookPage/index.jsx
+++ b/src/components/Pages/NotebookPage/index.jsx
@@ -7,15 +7,45 @@ import { notebooks } from '../../../content';
 import AudioPlayer from '../../Pures/AudioPlayer';
 import SEO from '../../Pures/SEO';
 import RelatedArticles from '../../Pures/RelatedArticles';
+import TableOfContents, { slugify } from '../../Pures/TableOfContents';
 import { getRelatedArticles } from '../../../utils/relatedArticles';
 import { readingTime } from '../../../utils/readingTime';
 import './style.scss';
 
+function extractHeadings(markdown) {
+  const headingRegex = /^(#{2,3})\s+(.+)$/gm;
+  const headings = [];
+  const usedIds = new Set();
+  let match;
+
+  while ((match = headingRegex.exec(markdown)) !== null) {
+    const level = match[1].length;
+    const text = match[2].replace(/[*_`~]/g, '').trim();
+    let id = slugify(text);
+
+    // Ensure unique IDs
+    if (usedIds.has(id)) {
+      let counter = 1;
+      while (usedIds.has(`${id}-${counter}`)) {
+        counter += 1;
+      }
+      id = `${id}-${counter}`;
+    }
+    usedIds.add(id);
+
+    headings.push({ id, text, level });
+  }
+
+  return headings;
+}
+
 function NotebookPage() {
   const { slug } = useParams();
   const [content, setContent] = React.useState('');
+  const [headings, setHeadings] = React.useState([]);
   const [hasAudio, setHasAudio] = React.useState(false);
   const [audioChecked, setAudioChecked] = React.useState(false);
+  const markdownRef = React.useRef(null);
 
   const notebook = notebooks.find((item) => item.slug === slug);
 
@@ -45,6 +75,7 @@ function NotebookPage() {
       const response = await fetch(notebookContent);
       const text = await response.text();
       setContent(text);
+      setHeadings(extractHeadings(text));
       hljs.highlightAll();
 
       // Check if audio overview exists
@@ -58,6 +89,30 @@ function NotebookPage() {
       setAudioChecked(true);
     })();
   }, []);
+
+  // Inject IDs into rendered headings after content renders
+  React.useEffect(() => {
+    if (!content || !markdownRef.current) return;
+
+    const container = markdownRef.current;
+    const headingEls = container.querySelectorAll('h2, h3');
+    const usedIds = new Set();
+
+    headingEls.forEach((el) => {
+      const text = el.textContent.replace(/[*_`~]/g, '').trim();
+      let id = slugify(text);
+
+      if (usedIds.has(id)) {
+        let counter = 1;
+        while (usedIds.has(`${id}-${counter}`)) {
+          counter += 1;
+        }
+        id = `${id}-${counter}`;
+      }
+      usedIds.add(id);
+      el.id = id;
+    });
+  }, [content]);
 
   // Show skeleton while loading
   if (content === '') {
@@ -119,7 +174,9 @@ function NotebookPage() {
         </div>
       </header>
 
-      <div className="markdown-body">
+      {headings.length >= 3 && <TableOfContents headings={headings} />}
+
+      <div className="markdown-body" ref={markdownRef}>
         <ReactMarkdown rehypePlugins={[rehypeRaw]}>
           {content}
         </ReactMarkdown>

--- a/src/components/Pures/TableOfContents/index.jsx
+++ b/src/components/Pures/TableOfContents/index.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import './style.scss';
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+function TableOfContents({ headings }) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [activeId, setActiveId] = React.useState('');
+
+  React.useEffect(() => {
+    if (!headings || headings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries.filter((entry) => entry.isIntersecting);
+        if (visibleEntries.length > 0) {
+          const topEntry = visibleEntries.reduce((a, b) =>
+            a.boundingClientRect.top < b.boundingClientRect.top ? a : b
+          );
+          setActiveId(topEntry.target.id);
+        }
+      },
+      {
+        rootMargin: '-80px 0px -70% 0px',
+        threshold: 0,
+      }
+    );
+
+    // Small delay to ensure headings are rendered with IDs
+    const timer = setTimeout(() => {
+      headings.forEach(({ id }) => {
+        const el = document.getElementById(id);
+        if (el) observer.observe(el);
+      });
+    }, 100);
+
+    return () => {
+      clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [headings]);
+
+  if (!headings || headings.length < 3) return null;
+
+  const handleClick = (e, id) => {
+    e.preventDefault();
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="table-of-contents">
+      {/* Desktop version */}
+      <div className="toc-desktop">
+        <div className="toc-title">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="8" y1="6" x2="21" y2="6" />
+            <line x1="8" y1="12" x2="21" y2="12" />
+            <line x1="8" y1="18" x2="21" y2="18" />
+            <line x1="3" y1="6" x2="3.01" y2="6" />
+            <line x1="3" y1="12" x2="3.01" y2="12" />
+            <line x1="3" y1="18" x2="3.01" y2="18" />
+          </svg>
+          <span>Daftar Isi</span>
+        </div>
+        <nav className="toc-nav">
+          {headings.map(({ id, text, level }) => (
+            <a
+              key={id}
+              href={`#${id}`}
+              className={`toc-link toc-link--level-${level}${activeId === id ? ' toc-link--active' : ''}`}
+              onClick={(e) => handleClick(e, id)}
+            >
+              {text}
+            </a>
+          ))}
+        </nav>
+      </div>
+
+      {/* Mobile version */}
+      <div className="toc-mobile">
+        <button
+          className="toc-toggle"
+          onClick={() => setIsOpen(!isOpen)}
+          type="button"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="8" y1="6" x2="21" y2="6" />
+            <line x1="8" y1="12" x2="21" y2="12" />
+            <line x1="8" y1="18" x2="21" y2="18" />
+            <line x1="3" y1="6" x2="3.01" y2="6" />
+            <line x1="3" y1="12" x2="3.01" y2="12" />
+            <line x1="3" y1="18" x2="3.01" y2="18" />
+          </svg>
+          <span>Daftar Isi</span>
+          <svg
+            className={`toc-chevron${isOpen ? ' toc-chevron--open' : ''}`}
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+        {isOpen && (
+          <nav className="toc-nav toc-nav--mobile">
+            {headings.map(({ id, text, level }) => (
+              <a
+                key={id}
+                href={`#${id}`}
+                className={`toc-link toc-link--level-${level}${activeId === id ? ' toc-link--active' : ''}`}
+                onClick={(e) => handleClick(e, id)}
+              >
+                {text}
+              </a>
+            ))}
+          </nav>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { TableOfContents, slugify };
+export default TableOfContents;

--- a/src/components/Pures/TableOfContents/style.scss
+++ b/src/components/Pures/TableOfContents/style.scss
@@ -1,0 +1,150 @@
+.table-of-contents {
+  margin-bottom: 32px;
+}
+
+.toc-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8125rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--on-background);
+  margin-bottom: 12px;
+
+  svg {
+    opacity: 0.7;
+  }
+}
+
+.toc-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 50vh;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.toc-link {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--on-background-grey);
+  text-decoration: none;
+  text-transform: none;
+  letter-spacing: 0;
+  line-height: 1.5;
+  padding: 4px 8px;
+  border-radius: var(--border-radius);
+  border: 2px solid transparent;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: var(--on-background);
+    background-color: var(--surface);
+    border-color: var(--on-background-border);
+  }
+
+  &--level-3 {
+    padding-left: 20px;
+    font-size: 0.8125rem;
+  }
+
+  &--active {
+    color: var(--on-background);
+    font-weight: 700;
+    background-color: var(--surface);
+    border-color: var(--on-background-border);
+    box-shadow: 2px 2px 0 var(--shadow-color);
+  }
+}
+
+/* Desktop: inline TOC before article */
+.toc-desktop {
+  border: 2px solid var(--on-background-border);
+  border-radius: var(--border-radius);
+  box-shadow: 4px 4px 0 var(--shadow-color);
+  background-color: var(--surface);
+  padding: 16px 20px;
+
+  .toc-title {
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--on-background-border);
+  }
+}
+
+.toc-mobile {
+  display: none;
+}
+
+.toc-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 16px;
+  border: 2px solid var(--on-background-border);
+  border-radius: var(--border-radius);
+  box-shadow: 3px 3px 0 var(--shadow-color);
+  background-color: var(--surface);
+  color: var(--on-background);
+  font-size: 0.8125rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+
+  &:hover {
+    transform: translate(1px, 1px);
+    box-shadow: 2px 2px 0 var(--shadow-color);
+  }
+
+  &:active {
+    transform: translate(2px, 2px);
+    box-shadow: none;
+  }
+}
+
+.toc-chevron {
+  margin-left: auto;
+  transition: transform 0.2s;
+
+  &--open {
+    transform: rotate(180deg);
+  }
+}
+
+.toc-nav--mobile {
+  margin-top: 8px;
+  padding: 12px 16px;
+  border: 2px solid var(--on-background-border);
+  border-radius: var(--border-radius);
+  background-color: var(--surface);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+/* Responsive */
+@media screen and (max-width: 767px) {
+  .toc-desktop {
+    display: none;
+  }
+
+  .toc-mobile {
+    display: block;
+    margin-bottom: 24px;
+  }
+
+  .toc-link {
+    font-size: 0.875rem;
+
+    &--level-3 {
+      padding-left: 16px;
+    }
+  }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -66,6 +66,10 @@
     box-sizing: border-box;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 body {
     overflow-x: hidden;
     overflow-y: scroll;


### PR DESCRIPTION
## Summary

Adds an automatic Table of Contents (Daftar Isi) for long notebook articles on dmds.dev.

## Changes

- **New component: `TableOfContents`** (`src/components/Pures/TableOfContents/`)
  - Parses markdown to extract h2 and h3 headings
  - Generates slug-based IDs for each heading (lowercase, hyphenated, special chars stripped)
  - Displays TOC only when article has 3+ headings
  - Active heading highlighting via IntersectionObserver
  - Desktop: inline neobrutalist box before article content
  - Mobile: collapsible toggle button that expands/collapses the TOC
  - Neobrutalist styling matching the site design (borders, shadows, rounded corners)

- **Modified: `NotebookPage`** (`src/components/Pages/NotebookPage/index.jsx`)
  - Extracts headings from markdown content on load
  - Injects IDs into rendered h2/h3 elements via post-render DOM processing
  - Renders TableOfContents component before the markdown body

- **Modified: global styles** (`src/styles/global.scss`)
  - Added `html { scroll-behavior: smooth; }` for smooth anchor scrolling

## Files Changed
- `src/components/Pages/NotebookPage/index.jsx` — heading extraction, ID injection, TOC rendering
- `src/components/Pures/TableOfContents/index.jsx` — new TOC component
- `src/components/Pures/TableOfContents/style.scss` — neobrutalist TOC styles
- `src/styles/global.scss` — smooth scroll behavior