### PR TITLE
feat: add scroll to top floating button

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -10,6 +10,7 @@ import TalksPage from '../Pages/TalksPage';
 
 import './style.scss';
 import ThemeContext from '../../contexts/ThemeContext';
+import ScrollToTop from '../Pures/ScrollToTop';
 
 function App() {
   const [theme, setTheme] = React.useState(() => localStorage.getItem('theme') || 'light');
@@ -44,6 +45,7 @@ function App() {
             </Routes>
 
           </div>
+          <ScrollToTop />
         </BrowserRouter>
       </div>
     </ThemeContext.Provider>

--- a/src/components/Pures/ScrollToTop/index.jsx
+++ b/src/components/Pures/ScrollToTop/index.jsx
@@ -1,0 +1,55 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import './style.scss';
+
+function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+  const [rafId, setRafId] = useState(null);
+
+  const handleScroll = useCallback(() => {
+    if (rafId) return;
+
+    const id = requestAnimationFrame(() => {
+      setVisible(window.scrollY > 400);
+      setRafId(null);
+    });
+    setRafId(id);
+  }, [rafId]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, [handleScroll, rafId]);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      className={`scroll-to-top ${visible ? 'scroll-to-top--visible' : ''}`}
+      onClick={scrollToTop}
+      aria-label="Kembali ke atas"
+      type="button"
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M10 4L3 11H7V16H13V11H17L10 4Z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  );
+}
+
+export default ScrollToTop;

--- a/src/components/Pures/ScrollToTop/style.scss
+++ b/src/components/Pures/ScrollToTop/style.scss
@@ -1,0 +1,60 @@
+.scroll-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  background-color: var(--primary);
+  color: white;
+  border: var(--border-width) var(--border-style) var(--on-background-border);
+  border-radius: 50%;
+  box-shadow: var(--shadow-offset) var(--shadow-offset) 0 var(--shadow-color);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(16px);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease, box-shadow 0.1s ease;
+  outline: none;
+
+  &:hover {
+    transform: translate(var(--shadow-offset), var(--shadow-offset));
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  svg {
+    display: block;
+  }
+
+  &--visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+
+    &:hover {
+      transform: translate(var(--shadow-offset), var(--shadow-offset));
+    }
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .scroll-to-top {
+    bottom: 1.25rem;
+    right: 1.25rem;
+    width: 40px;
+    height: 40px;
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a floating "Scroll to Top" button with neobrutalist styling that appears when the user scrolls down more than 400px.

### Details
- **Component**: `src/components/Pures/ScrollToTop/index.jsx`
- **Styling**: `src/components/Pures/ScrollToTop/style.scss`
- Smooth scroll to top on click
- Appears after scrolling 400px down, with fade-in/fade-out CSS transitions (opacity + transform)
- Uses `requestAnimationFrame` for throttled scroll listener (passive event listener)
- Proper cleanup of event listener on unmount
- Neobrutalist style consistent with site design: 2px border, offset shadow, primary color background, rounded (50%), hover shadow translate effect
- Responsive: smaller button and adjusted position on mobile
- Accessible: `aria-label="Kembali ke atas"`, focus-visible outline
- Uses site CSS variables (`--primary`, `--border-width`, `--shadow-offset`, `--shadow-color`, `--on-background-border`)
- Placed inside `BrowserRouter` in App so it works across all pages
- Z-index 900 (below any modal, above content)