### PR TITLE
fix: resolve scroll-to-top collision with audio player

### DIFF
--- a/src/components/Pures/ScrollToTop/index.jsx
+++ b/src/components/Pures/ScrollToTop/index.jsx
@@ -3,6 +3,7 @@ import './style.scss';
 
 function ScrollToTop() {
   const [visible, setVisible] = useState(false);
+  const [hasAudioPlayer, setHasAudioPlayer] = useState(false);
   const [rafId, setRafId] = useState(null);
 
   const handleScroll = useCallback(() => {
@@ -24,13 +25,33 @@ function ScrollToTop() {
     };
   }, [handleScroll, rafId]);
 
+  // Detect if audio player is present in the DOM
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setHasAudioPlayer(!!document.querySelector('.audio-player'));
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // Initial check
+    setHasAudioPlayer(!!document.querySelector('.audio-player'));
+
+    return () => observer.disconnect();
+  }, []);
+
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
+  const classes = [
+    'scroll-to-top',
+    visible && 'scroll-to-top--visible',
+    hasAudioPlayer && 'scroll-to-top--with-audio',
+  ].filter(Boolean).join(' ');
+
   return (
     <button
-      className={`scroll-to-top ${visible ? 'scroll-to-top--visible' : ''}`}
+      className={classes}
       onClick={scrollToTop}
       aria-label="Kembali ke atas"
       type="button"

--- a/src/components/Pures/ScrollToTop/style.scss
+++ b/src/components/Pures/ScrollToTop/style.scss
@@ -17,7 +17,7 @@
   opacity: 0;
   transform: translateY(16px);
   pointer-events: none;
-  transition: opacity 0.3s ease, transform 0.3s ease, box-shadow 0.1s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease, box-shadow 0.1s ease, bottom 0.3s ease;
   outline: none;
 
   &:hover {
@@ -43,6 +43,11 @@
       transform: translate(var(--shadow-offset), var(--shadow-offset));
     }
   }
+
+  // Push up when audio player is visible
+  &--with-audio {
+    bottom: 5.5rem;
+  }
 }
 
 @media screen and (max-width: 767px) {
@@ -55,6 +60,10 @@
     svg {
       width: 16px;
       height: 16px;
+    }
+
+    &--with-audio {
+      bottom: 4.75rem;
     }
   }
 }


### PR DESCRIPTION
Add --with-audio modifier class that pushes the button above the fixed audio player bar using MutationObserver to detect audio player presence.