### PR TITLE
fix: notebook page not updating on related article click

### DIFF
--- a/src/components/Pages/NotebookPage/index.jsx
+++ b/src/components/Pages/NotebookPage/index.jsx
@@ -70,6 +70,15 @@ function NotebookPage() {
     : plainText || notebook.title;
 
   React.useEffect(() => {
+    // Reset state when slug changes
+    setContent('');
+    setHeadings([]);
+    setHasAudio(false);
+    setAudioChecked(false);
+
+    // Scroll to top when navigating between articles
+    window.scrollTo(0, 0);
+
     (async () => {
       const { content: notebookContent } = notebook;
       const response = await fetch(notebookContent);
@@ -88,7 +97,7 @@ function NotebookPage() {
       }
       setAudioChecked(true);
     })();
-  }, []);
+  }, [slug]);
 
   // Inject IDs into rendered headings after content renders
   React.useEffect(() => {


### PR DESCRIPTION
The useEffect had empty dependency array [], so when React Router navigated to a new slug, the component did not re-fetch content. Added slug to dependency array, reset all state on navigation, and scroll to top.